### PR TITLE
small fix to the CDDL

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -196,9 +196,11 @@ sd-protected = {
    * key => any
 }
 
+salted-array = [ +bstr .cbor salted ]
+
 unprotected-presentation = {
    &(sd_kbt: TBD2) ^ => bstr .cbor kbt-cwt,
-   ? &(sd_claims: TBD1) ^ => bstr .cbor [ + bstr .cbor salted ],
+   ? &(sd_claims: TBD1) ^ => bstr .cbor salted-array,
    * key => any
 }
 

--- a/sd-cwts.cddl
+++ b/sd-cwts.cddl
@@ -33,14 +33,16 @@ kbt-protected = {
    * key => any   
 }
 
+salted-array = [ +bstr .cbor salted ]
+
 unprotected-presentation = {
    &(sd_kbt: TBD2) ^ => bstr .cbor kbt-cwt,
-   ? &(sd_claims: TBD1) ^ => [ +bstr .cbor salted ],
+   ? &(sd_claims: TBD1) ^ => bstr .cbor salted-array,
    * key => any   
 }
 
 unprotected-issued = {
-   ? &(sd_claims: TBD1) ^ => [ +bstr .cbor salted ],
+   ? &(sd_claims: TBD1) ^ => bstr .cbor salted-array,
    * key => any   
 }
 


### PR DESCRIPTION
fix to full cddl and one instance of the same CDDL in the body of the draft

CDDL was not happy with:

```
? &(sd_claims: TBD1) ^ => [ +bstr .cbor salted ]
```

, so I replaced with:

```
? &(sd_claims: TBD1) ^ => bstr .cbor salted-array,
```

where `salted-array` is `salted-array = [ +bstr .cbor salted ]`