### PR TITLE
turn the cnonce in the kbt optional

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -355,7 +355,7 @@ claim (true), the `region` claim (California), and the other element in the
 ]>>
 ~~~
 
-The Holder MAY also fetch a nonce from the Verifier to prevent replay.
+The Holder MAY fetch a nonce from the Verifier to prevent replay, or obtain a nonce acceptable to the verifier through a process similar to the one described in draft-ietf-httpbis-unprompted-auth-12.
 
 Finally, the Holder generates a Selective Disclosure Key Binding Token
 (SD-KBT) that ties together any disclosures, the Verifier nonce and target

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -355,8 +355,7 @@ claim (true), the `region` claim (California), and the other element in the
 ]>>
 ~~~
 
-The Holder will also typically fetch a nonce from the Verifier to prevent
-replay.
+The Holder MAY also fetch a nonce from the Verifier to prevent replay.
 
 Finally, the Holder generates a Selective Disclosure Key Binding Token
 (SD-KBT) that ties together any disclosures, the Verifier nonce and target
@@ -603,7 +602,7 @@ kbt-payload = {
     ? &(exp: 4) ^ => int,  ; 1883000000
     ? &(nbf: 5) ^ => int,  ; 1683000000
       &(iat: 6) ^ => int,  ; 1683000000
-      &(cnonce: 39) ^ => bstr,
+    ? &(cnonce: 39) ^ => bstr,
       ; matches the hash of sd_claims in the presentation token
       &(sd_hash: TBD3) ^ => bstr,
     * key => any


### PR DESCRIPTION
Hi,

this fixes a small inconsistency in the draft since it is stated at the beginning of the draft that `To protect against replay attacks, the verifier SHOULD provide a nonce, and reject requests that do not include an acceptable an nonce (cnonce). This guidance can be ignored in cases where replay attacks are mitigated at another layer`.

There are two options here: either turn the claim optional or have the Holder use a fixed nonce in case he did not get one from the Verifier. I prefer the former. 

Thoughts ?