### PR TITLE
Use CBOR tag for redacted (array) claim elements

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -418,7 +418,7 @@ salted-array = [ +bstr .cbor salted ]
 
 When a blinded claim is a key in a map, its blinded claim hash is added to a `redacted_claim_keys` array claim in the CWT payload that is at the same level of hierarchy as the key being blinded.
 
-When blinding an individual item in an array, the value of the item is replaced with the digested salted hash as a CBOR binary string, wrapped with CBOR tag 60.
+When blinding an individual item in an array, the value of the item is replaced with the digested salted hash as a CBOR binary string, wrapped with a CBOR tag (requested tag number 60).
 
 ~~~ cddl
 redacted_claim_element = #6.60( bstr .size 16 )
@@ -714,7 +714,7 @@ The following completed registration template per RFC8152 is provided:
 
 The binary string inside the tag is a selective disclosure redacted claim element of an array.
 
-* Tag: 60 (requested)
+* Tag: TBD9 (requested assignment 60)
 * Data Item: byte string
 * Semantics: A selective disclosure redacted (array) claim element.
 * Specification Document(s): RFC XXXX
@@ -723,7 +723,7 @@ The binary string inside the tag is a selective disclosure redacted claim elemen
 
 The array claim element, or map key and value inside the "To be redacted" tag is intended to be redacted using selective disclosure.
 
-* Tag: 58 (requested)
+* Tag: TBD10 (requested assignment 58)
 * Data Item: (any)
 * Semantics: An array claim element, or map key and value intended to be redacted.
 * Specification Document(s): RFC XXXX

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -290,11 +290,8 @@ First she requests an SD-CWT from her issuer. The issuer generates an SD-CWT as 
     / swversion / 271 : [
       "3.5.5",
       / redacted version "4.1.7" /
-      {
-        / redacted_claim_element / 65555:
-        h'a0f74264a8c97655c958aff3687f1390' +
-        h'ed0ab6f64cd78ba43c3fefee0de7b835'
-      }
+      60(h'a0f74264a8c97655c958aff3687f1390' +
+         h'ed0ab6f64cd78ba43c3fefee0de7b835')
     ],
     "address": {
         "country" : "us",            / United States /
@@ -419,12 +416,12 @@ decoy = [
 salted-array = [ +bstr .cbor salted ]
 ~~~
 
-When a blinded claim is a key in a map, its blinded claim hash is added to a `redacted_values` array claim in the CWT payload that is at the same level of hierarchy as the key being blinded.
+When a blinded claim is a key in a map, its blinded claim hash is added to a `redacted_claim_keys` array claim in the CWT payload that is at the same level of hierarchy as the key being blinded.
 
-When blinding an individual item in an array, the value of the item is replaced with a CBOR map containing only the special key "...".
+When blinding an individual item in an array, the value of the item is replaced with the digested salted hash as a CBOR binary string, wrapped with CBOR tag 60.
 
 ~~~ cddl
-redacted_element = { "...": any }
+redacted_claim_element = #6.60( bstr .size 16 )
 ~~~
 
 Blinded claims can be nested. For example, both individual keys in the `address` claim, and the entire `address` element can be separately blinded.
@@ -711,6 +708,26 @@ Value Registry: (empty)
 Description: Key binding token for disclosed claims
 Reference: RFC XXXX
 
+## CBOR Tags
+
+### Redacted claim element tag
+
+The binary string inside the tag is a selective disclosure redacted claim element of an array.
+
+Tag: 60 (requested)
+Data Item: byte string
+Semantics: A selective disclosure redacted (array) claim element.
+Specification Document(s): RFC XXXX
+
+### To be redacted tag
+
+The array claim element, or map key and value inside the "To be redacted" tag is intended to be redacted using selective disclosure.
+
+Tag: 58 (requested)
+Data Item: (any)
+Semantics: An array claim element, or map key and value intended to be redacted.
+Specification Document(s): RFC XXXX
+
 ## CBOR Web Token (CWT) Claims
 
 IANA is requested to add the following entries to the CWT claims registry (https://www.iana.org/assignments/cwt/cwt.xhtml).
@@ -725,18 +742,6 @@ Claim Name: redacted_claim_keys
 Claim Description: Redacted Claim Keys in a map.
 JWT Claim Name: _sd
 Claim Key: TBD5 (request assignment 65556)
-Claim Value Type(s): array of bstr
-Change Controller: IETF
-Specification Document(s): RFC XXXX
-
-### redacted_claim_element
-
-The following completed registration template per RFC8392 is provided:
-
-Claim Name: redacted_claim_element
-Claim Description: Redacted element of an array
-JWT Claim Name: ...
-Claim Key: TBD6 (request assignment 65555)
 Claim Value Type(s): array of bstr
 Change Controller: IETF
 Specification Document(s): RFC XXXX

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -279,7 +279,7 @@ First she requests an SD-CWT from her issuer. The issuer generates an SD-CWT as 
       }
     },
     / sd_alg /  12       : -16, / SHA-256 /
-    / redacted_claim_keys / 65556 : [
+    / redacted_claim_keys / -65536 : [
         / redacted age_at_least_18 /
         h'7e6e350907d0ba3aa7ae114f8da5b360' +
         h'601c0bb7995cd40049b98e4f58fb6ec0',
@@ -295,7 +295,7 @@ First she requests an SD-CWT from her issuer. The issuer generates an SD-CWT as 
     ],
     "address": {
         "country" : "us",            / United States /
-        / redacted_claim_keys / 65556 : [
+        / redacted_claim_keys / -65536 : [
             / redacted region /
             h'c47e3b047c1cd6d9d1e1e01514bc2ec9' +
             h'ed010ac9ae1c93403ec72572bb1e00e7',
@@ -497,7 +497,7 @@ sd-payload = {
     ;
     ; sd-cwt new claims
       &(sd_alg: 12) ^ => int,            ; -16 for sha-256
-    ? &(redacted_keys: 65556) ^ => [ * bstr ],
+    ? &(redacted_keys: -65536) ^ => [ * bstr ],
     * key => any
 }
 ~~~
@@ -741,7 +741,7 @@ The following completed registration template per RFC8392 is provided:
 Claim Name: redacted_claim_keys
 Claim Description: Redacted Claim Keys in a map.
 JWT Claim Name: _sd
-Claim Key: TBD5 (request assignment 65556)
+Claim Key: TBD5 (request assignment -65536)
 Claim Value Type(s): array of bstr
 Change Controller: IETF
 Specification Document(s): RFC XXXX
@@ -865,9 +865,9 @@ THe COSE equivalent of `application/kb+jwt` is `application/kb+cwt`.
 
 ## Redaction Claims
 
-The COSE equivalent of `_sd` is TBD5 (requested assignment 65556).
+The COSE equivalent of `_sd` is TBD5 (requested assignment -65536).
 
-The COSE equivalent of `...` is TBD6 (requested assignment 65555).
+The COSE equivalent of `...` is a CBOR tag (requested assignment 60) of the digested salted claim.
 
 ## Issuance
 

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -690,23 +690,23 @@ IANA is requested to add the following entries to the CWT claims registry (https
 
 The following completed registration template per RFC8152 is provided:
 
-Name: sd_claims
-Label: TBD9 (requested assignment 17)
-Value Type: bstr
-Value Registry: (empty)
-Description: A list of selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-Reference: RFC XXXX
+* Name: sd_claims
+* Label: TBD9 (requested assignment 17)
+* Value Type: bstr
+* Value Registry: (empty)
+* Description: A list of selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
+* Reference: RFC XXXX
 
 ### sd_kbt
 
 The following completed registration template per RFC8152 is provided:
 
-Name: sd_kbt
-Label: TBD8 (requested assignment 18)
-Value Type: bstr
-Value Registry: (empty)
-Description: Key binding token for disclosed claims
-Reference: RFC XXXX
+* Name: sd_kbt
+* Label: TBD8 (requested assignment 18)
+* Value Type: bstr
+* Value Registry: (empty)
+* Description: Key binding token for disclosed claims
+* Reference: RFC XXXX
 
 ## CBOR Tags
 
@@ -714,19 +714,19 @@ Reference: RFC XXXX
 
 The binary string inside the tag is a selective disclosure redacted claim element of an array.
 
-Tag: 60 (requested)
-Data Item: byte string
-Semantics: A selective disclosure redacted (array) claim element.
-Specification Document(s): RFC XXXX
+* Tag: 60 (requested)
+* Data Item: byte string
+* Semantics: A selective disclosure redacted (array) claim element.
+* Specification Document(s): RFC XXXX
 
 ### To be redacted tag
 
 The array claim element, or map key and value inside the "To be redacted" tag is intended to be redacted using selective disclosure.
 
-Tag: 58 (requested)
-Data Item: (any)
-Semantics: An array claim element, or map key and value intended to be redacted.
-Specification Document(s): RFC XXXX
+* Tag: 58 (requested)
+* Data Item: (any)
+* Semantics: An array claim element, or map key and value intended to be redacted.
+* Specification Document(s): RFC XXXX
 
 ## CBOR Web Token (CWT) Claims
 
@@ -738,49 +738,49 @@ IANA is requested to add the following entries to the CWT claims registry (https
 
 The following completed registration template per RFC8392 is provided:
 
-Claim Name: redacted_claim_keys
-Claim Description: Redacted Claim Keys in a map.
-JWT Claim Name: _sd
-Claim Key: TBD5 (request assignment -65536)
-Claim Value Type(s): array of bstr
-Change Controller: IETF
-Specification Document(s): RFC XXXX
+* Claim Name: redacted_claim_keys
+* Claim Description: Redacted Claim Keys in a map.
+* JWT Claim Name: _sd
+* Claim Key: TBD5 (request assignment -65536)
+* Claim Value Type(s): array of bstr
+* Change Controller: IETF
+* Specification Document(s): RFC XXXX
 
 ### sd_alg
 
 The following completed registration template per RFC8392 is provided:
 
-Claim Name: sd_alg
-Claim Description: Hash algorithm used for selective disclosure
-JWT Claim Name: _sd_alg
-Claim Key: TBD4 (request assignment 12)
-Claim Value Type(s): integer
-Change Controller: IETF
-Specification Document(s): RFC XXXX
+* Claim Name: sd_alg
+* Claim Description: Hash algorithm used for selective disclosure
+* JWT Claim Name: _sd_alg
+* Claim Key: TBD4 (request assignment 12)
+* Claim Value Type(s): integer
+* Change Controller: IETF
+* Specification Document(s): RFC XXXX
 
 ### sd_hash
 
 The following completed registration template per RFC8392 is provided:
 
-Claim Name: sd_hash
-Claim Description: Hash of encoded disclosed claims
-JWT Claim Name: sd_hash
-Claim Key: TBD3 (request assignment 11)
-Claim Value Type(s): bstr
-Change Controller: IETF
-Specification Document(s): RFC XXXX
+* Claim Name: sd_hash
+* Claim Description: Hash of encoded disclosed claims
+* JWT Claim Name: sd_hash
+* Claim Key: TBD3 (request assignment 11)
+* Claim Value Type(s): bstr
+* Change Controller: IETF
+* Specification Document(s): RFC XXXX
 
 ### vct
 
 The following completed registration template per RFC8392 is provided:
 
-Claim Name: vct
-Claim Description: Verifiable credential type
-JWT Claim Name: vct
-Claim Key: TBD7 (request assignment 15)
-Claim Value Type(s): bstr
-Change Controller: IETF
-Specification Document(s): RFC XXXX
+* Claim Name: vct
+* Claim Description: Verifiable credential type
+* JWT Claim Name: vct
+* Claim Key: TBD7 (request assignment 15)
+* Claim Value Type(s): bstr
+* Change Controller: IETF
+* Specification Document(s): RFC XXXX
 
 ## Media Types
 
@@ -804,9 +804,9 @@ The following completed registration template is provided:
 * Applications that use this media type: TBD
 * Fragment identifier considerations: n/a
 * Additional information:
-      Magic number(s): n/a
-      File extension(s): n/a
-      Macintosh file type code(s): n/a
+    - Magic number(s): n/a
+    - File extension(s): n/a
+    - Macintosh file type code(s): n/a
 * Person & email address to contact for further information:
   Michael Prorock, mprorock@mesur.io
 * Intended usage: COMMON
@@ -833,9 +833,9 @@ The following completed registration template is provided:
 * Applications that use this media type: TBD
 * Fragment identifier considerations: n/a
 * Additional information:
-      Magic number(s): n/a
-      File extension(s): n/a
-      Macintosh file type code(s): n/a
+     - Magic number(s): n/a
+     - File extension(s): n/a
+     - Macintosh file type code(s): n/a
 * Person & email address to contact for further information:
   Orie Steele, orie@transmute.industries
 * Intended usage: COMMON

--- a/sd-cwt-example.cbor-diag
+++ b/sd-cwt-example.cbor-diag
@@ -56,17 +56,17 @@
     / cnonce / 39 : h'12345678',
     / sd_hash / 11       : h'abcdef12',
     / sd_alg /  12       : -16, / SHA-256 /
-    / redacted_keys / 13 : [ 
+    / redacted_claim_keys / -65536 : [ 
         h'abbdefef',  / redacted age_over_18 /
         h'132d75e7'  / redacted age_over_21 /
     ],
     / swversion / 271 : [
       "3.5.5",
-      { "...": h'45dd87af'  /redacted version element/ }
+      60(h'45dd87af') /redacted version element/ }
     ],
     "address": {
         "country" : "us",            / United States /
-        /redacted_keys/ 13 : [
+        /redacted_claim_keys/ -65536 : [
             h'adb7060403da225b',  / redacted region /
             h'e04bdfc44d3d40bc'   / redacted post_code /
         ]

--- a/sd-cwt-example.cbor-diag
+++ b/sd-cwt-example.cbor-diag
@@ -56,7 +56,7 @@
     / cnonce / 39 : h'12345678',
     / sd_hash / 11       : h'abcdef12',
     / sd_alg /  12       : -16, / SHA-256 /
-    / redacted_claim_keys / -65536 : [ 
+    / redacted_claim_keys / -65536 : [
         h'abbdefef',  / redacted age_over_18 /
         h'132d75e7'  / redacted age_over_21 /
     ],

--- a/sd-cwts.cddl
+++ b/sd-cwts.cddl
@@ -64,7 +64,7 @@ sd-payload = {
     ; sd-cwt new claims
       &(sd_hash: TBD3) ^ => bstr, 
       &(sd_alg: TBD4) ^ => int,            ; -16 for sha-256
-    ? &(redacted_keys: TBD5) ^ => [ * bstr ],
+    ? &(redacted_claim_keys: TBD5) ^ => [ * bstr ],
     * key => any   
 }
 
@@ -78,7 +78,7 @@ kbt-payload = {
     * key => any   
 }
 
-;redacted_element = { "...": bstr }
+;redacted_claim_element = #6.60( bstr .size 16 )
 salted = salted-claim / salted-element
 salted-claim = [
   bstr ;.size 16,     ; 128-bit salt
@@ -95,4 +95,4 @@ TBD1 = 17
 TBD2 = 18
 TBD3 = 11
 TBD4 = 12
-TBD5 = 13
+TBD5 = -65536


### PR DESCRIPTION
- Replace older redacted (array) claim element forms `{"...", h'1234abcd'}` and `{ / redacted_claim_element / 65555: h'1234abcd'}` with a CBOR tagged digest: `60(h'1234abcd')`
- Register the CBOR tag to indicate a redacted claim element
- Consistently use the names `redacted_claim_elements` and `redacted_claim_keys`
- Replace 65556 with -65536 to be a shorter to represent, and possibly rarer number to encounter as a map key (note that this syntax may be replaced in a future PR)
- Make the appropriate changes consistently in the examples and in the CDDL file
- Register a different CBOR tag to indicate the intent to redact a claim (key, or element)
- Fix the formatting of the IANA registration section