### PR TITLE
Fix kcwt encoding; Add COSE Key thumbrints

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# Automatically generated CODEOWNERS
-# Regenerate with `make update-codeowners`
-draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@or13.io @henkbirkholz @rohanmahy 
+# **Manually** generated CODEOWNERS
+# Please do NOT run `make update-codeowners` or you will bork this
+draft-ietf-spice-sd-cwt.md @mprorock @OR13 @henkbirkholz @rohanmahy 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@or13.io henk.birkholz@ietf.contact rohan.ietf@gmail.com
+draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@or13.io @henkbirkholz @rohanmahy 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@transmute.industries henk.birkholz@ietf.contact rohan.ietf@gmail.com
+draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@or13.io henk.birkholz@ietf.contact rohan.ietf@gmail.com

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Automatically generated CODEOWNERS
 # Regenerate with `make update-codeowners`
-draft-ietf-spice-sd-cwt.md orie@or13.io
+draft-ietf-spice-sd-cwt.md mprorock@mesur.io orie@transmute.industries henk.birkholz@ietf.contact rohan.ietf@gmail.com

--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -16,6 +16,8 @@ jobs:
   build:
     name: "Archive Issues and Pull Requests"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: "Checkout"
       uses: actions/checkout@v4
@@ -37,6 +39,6 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Save Archive"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: archive.json

--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -18,6 +18,8 @@ jobs:
   build:
     name: "Update Editor's Copy"
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - name: "Checkout"
       uses: actions/checkout@v4
@@ -51,7 +53,7 @@ jobs:
         token: ${{ github.token }}
 
     - name: "Archive Built Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: |
           draft-*.html

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,9 +49,9 @@ jobs:
       with:
         make: upload
       env:
-         UPLOAD_EMAIL: ${{ inputs.email }}
+        UPLOAD_EMAIL: ${{ inputs.email }}
 
     - name: "Archive Submitted Drafts"
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: "versioned/draft-*-[0-9][0-9].*"

--- a/.gitignore
+++ b/.gitignore
@@ -7,9 +7,9 @@
 *~
 .tags
 /*-[0-9][0-9].xml
+/.*.mk
 /.gems/
 /.refcache
-/.targets.mk
 /.venv/
 /.vscode/
 /lib

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ repository constitutes Contributions to the IETF Standards Process
 You agree to comply with all applicable IETF policies and procedures, including,
 BCP 78, 79, the TLP, and the TLP rules regarding code components (e.g. being
 subject to a Simplified BSD License) in Contributions.
+
+
 ## Working Group Information
 
 Discussion of this work occurs on the [Secure Patterns for Internet CrEdentials

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,12 @@ include $(LIBDIR)/main.mk
 $(LIBDIR)/main.mk:
 ifneq (,$(shell grep "path *= *$(LIBDIR)" .gitmodules 2>/dev/null))
 	git submodule sync
-	git submodule update $(CLONE_ARGS) --init
+	git submodule update --init
 else
-	git clone -q --depth 10 $(CLONE_ARGS) \
-	    -b main https://github.com/martinthomson/i-d-template $(LIBDIR)
+ifneq (,$(wildcard $(ID_TEMPLATE_HOME)))
+	ln -s "$(ID_TEMPLATE_HOME)" $(LIBDIR)
+else
+	git clone -q --depth 10 -b main \
+	    https://github.com/martinthomson/i-d-template $(LIBDIR)
+endif
 endif

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SPICE SD-CWT
 
-This is the working area for the IETF [SPICE Working Group](https://datatracker.ietf.org/wg/spice/documents/) Internet-Draft, "SPICE SD-CWT".
+This is the working area for the IETF [SPICE Working Group](https://datatracker.ietf.org/group/spice/documents/) Internet-Draft, "SPICE SD-CWT".
 
 * [Editor's Copy](https://ietf-wg-spice.github.io/draft-ietf-spice-sd-cwt/#go.draft-ietf-spice-sd-cwt.html)
 * [Datatracker Page](https://datatracker.ietf.org/doc/draft-ietf-spice-sd-cwt)
@@ -27,3 +27,4 @@ $ make
 
 Command line usage requires that you have the necessary software installed.  See
 [the instructions](https://github.com/martinthomson/i-d-template/blob/main/doc/SETUP.md).
+

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -398,15 +398,15 @@ Finally, the Holder generates a Selective Disclosure Key Binding Token (SD-KBT) 
 The issued SD-CWT is placed in the `kcwt` (Confirmation Key CWT) protected header field (defined in {{!RFC9528}}).
 
 ~~~
-/ sd_kbt    / 18 : << 18([
+/ kcwt / 13 :  18([
   / protected / << {
-      / alg /  1 : -7 / ES256 /,
-      / typ /  16 : "application/kb+cwt",
-      / kcwt / 13 :
-        / *** SD-CWT from Issuer goes here       /
-        /  with Holder's choice of disclosures   /
-        /  in the SD-CWT unprotected header  *** /
-        h'0123456789abcdef...0123'
+    / alg /  1 : -7 / ES256 /,
+    / typ /  16 : "application/kb+cwt",
+    / kcwt / 13 :
+      / *** SD-CWT from Issuer goes here       /
+      /  with Holder's choice of disclosures   /
+      /  in the SD-CWT unprotected header  *** /
+      h'0123456789abcdef...0123'
   } >>,
   / unprotected / {},
   / payload / << {
@@ -415,7 +415,7 @@ The issued SD-CWT is placed in the `kcwt` (Confirmation Key CWT) protected heade
     / iat     / 6    : 1725283443, / 2024-09-02T06:24:03Z /
   } >>,
   / signature / h'1237af2e678945'  / TODO: fix /
-]) >>
+])
 ~~~
 
 Together the digests in protected parts of the issued SD-CWT, and the disclosures hashed in unprotected header of the `issuer_sd_cwt` are used by the Verifier to confirm the disclosed claims.

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -1134,6 +1134,13 @@ Note: RFC Editor, please remove this entire section on publication.
 - correct that an SD-CWT may have zero redacted claims
 - improve the walkthrough of computing a disclosure
 - clarify that duplicate map keys are not allowed, and how tagged keys are represented.
+- added security considerations section (#42) and text about privacy and linkability risks (#43)
+- register SD-CWT and SD-KBT as content formats in CoAP registry (#39)
+- updated media types registrations to have more useful contacts ($44)
+- add description of decoy digests **TODO**
+- add nested examples **TODO**
+- regenerate all examples with correct signatures **TODO**
+- provide test vectors **TODO**
 
 ## draft-ietf-spice-sd-cwt-02
 

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -401,12 +401,11 @@ The issued SD-CWT is placed in the `kcwt` (Confirmation Key CWT) protected heade
 / kcwt / 13 :  18([
   / protected / << {
     / alg /  1 : -7 / ES256 /,
-    / typ /  16 : "application/kb+cwt",
-    / kcwt / 13 :
+    / typ /  16 : "application/kb+cwt",q
+    / kcwt / 13 : ...
       / *** SD-CWT from Issuer goes here       /
       /  with Holder's choice of disclosures   /
       /  in the SD-CWT unprotected header  *** /
-      h'0123456789abcdef...0123'
   } >>,
   / unprotected / {},
   / payload / << {
@@ -1013,9 +1012,61 @@ The validation process for SD-CWT is similar to SD-JWT, however, JSON Objects ar
 
 ## Subject / Holder
 
-Holder key pair in JWK format
+Holder COSE key pair in EDN format
+
+~~~ cbor-diag
+{
+  /kty/  1 : 2, /EC/
+  /alg/  3 : -7, /ES256/
+  /crv/ -1 : 1, /P-256/
+  /x/   -2 : h'8554eb275dcd6fbd1c7ac641aa2c90d9
+               2022fd0d3024b5af18c7cc61ad527a2d',
+  /y/   -3 : h'4dc7ae2c677e96d0cc82597655ce92d5
+               503f54293d87875d1e79ce4770194343',
+  /d/   -4 : h'5759a86e59bb3b002dde467da4b52f3d
+               06e6c2cd439456cf0485b9b864294ce5'
+}
+~~~
+
+The fields necessary for the COSE Key Thumbprint {{!RFC9679}}
+in EDN format:
+
+~~~ cbor-diag
+{
+  /kty/  1 : 2, /EC/
+  /crv/ -1 : 1, /P-256/
+  /x/   -2 : h'8554eb275dcd6fbd1c7ac641aa2c90d9
+               2022fd0d3024b5af18c7cc61ad527a2d',
+  /y/   -3 : h'4dc7ae2c677e96d0cc82597655ce92d5
+               503f54293d87875d1e79ce4770194343',
+}
+~~~
+
+The same map in CBOR pretty printing
+
+~~~ cbor-pretty
+A4                                      # map(4)
+   01                                   # unsigned(1)
+   02                                   # unsigned(2)
+   20                                   # negative(0)
+   01                                   # unsigned(1)
+   21                                   # negative(1)
+   58 20                                # bytes(32)
+      8554EB275DCD6FBD1C7AC641AA2C90D92022FD0D3024B5AF18C7CC61AD527A2D
+   22                                   # negative(2)
+   58 20                                # bytes(32)
+      4DC7AE2C677E96D0CC82597655CE92D5503F54293D87875D1E79CE4770194343
+~~~
+
+The COSE thumbprint (in hexadecimal)--SHA256 hash of the thumbprint fields:
 
 ~~~
+8343d73cdfcb81f2c7cd11a5f317be8eb34e4807ec8c9ceb282495cffdf037e0
+~~~
+
+Holder key pair in JWK format
+
+~~~ json
 {
   "kty": "EC",
   "alg": "ES256",
@@ -1029,7 +1080,7 @@ Holder key pair in JWK format
 
 Input to Holder public JWK thumbprint (ignore line breaks)
 
-~~~
+~~~ json
 {"crv":"P-256","kty":"EC","x":"hVTrJ13Nb70cesZBqiyQ2SAi_Q0wJLWvGMfMYa1S
 ei0","y":"TceuLGd-ltDMgll2Vc6S1VA_VCk9h4ddHnnOR3AZQ0M"}
 ~~~
@@ -1055,7 +1106,7 @@ JLWvGMfMYa1Sei1Nx64sZ36W0MyCWXZVzpLVUD9UKT2Hh10eec5HcBlDQw==
 -----END PUBLIC KEY-----
 ~~~
 
-Hodler private key in PEM format
+Holder private key in PEM format
 
 ~~~
 -----BEGIN PRIVATE KEY-----
@@ -1066,6 +1117,61 @@ ta8Yx8xhrVJ6LU3HrixnfpbQzIJZdlXOktVQP1QpPYeHXR55zkdwGUND
 ~~~
 
 ## Issuer
+
+Issuer COSE key pair in Extended Diagnostic Notation (EDN)
+
+~~~ cbor-diag
+{
+  /kty/  1 : 2, /EC/
+  /kid/  2 : "https://issuer.example/cwk3.cbor",
+  /alg/  3 : -35, /ES384/
+  /crv/ -1 : 2, /P-384/
+  /x/   -2 : h'c31798b0c7885fa3528fbf877e5b4c3a6dc67a5a5dc6b307
+               b728c3725926f2abe5fb4964cd91e3948a5493f6ebb6cbbf',
+  /y/   -3 : h'8f6c7ec761691cad374c4daa9387453f18058ece58eb0a8e
+               84a055a31fb7f9214b27509522c159e764f8711e11609554',
+  /d/   -4 : h'71c54d2221937ea612db1221f0d3ddf771c9381c4e3be41d
+               5aa0a89d685f09cfef74c4bbf104783fd57e87ab227d074c'
+}
+~~~
+
+The fields necessary for the COSE Key Thumbprint {{!RFC9679}}
+in EDN format:
+
+~~~ cbor-diag
+{
+  /kty/  1 : 2, /EC/
+  /crv/ -1 : 2, /P-384/
+  /x/   -2 : h'c31798b0c7885fa3528fbf877e5b4c3a6dc67a5a5dc6b307
+               b728c3725926f2abe5fb4964cd91e3948a5493f6ebb6cbbf',
+  /y/   -3 : h'8f6c7ec761691cad374c4daa9387453f18058ece58eb0a8e
+               84a055a31fb7f9214b27509522c159e764f8711e11609554'
+}
+~~~
+
+The same map in CBOR pretty printing
+
+~~~ cbor-pretty
+A4                                      # map(5)
+   01                                   # unsigned(1)
+   02                                   # unsigned(2)
+   20                                   # negative(0)
+   02                                   # unsigned(2)
+   21                                   # negative(1)
+   58 30                                # bytes(48)
+      C31798B0C7885FA3528FBF877E5B4C3A6DC67A5A5DC6B307
+      B728C3725926F2ABE5FB4964CD91E3948A5493F6EBB6CBBF
+   22                                   # negative(2)
+   58 30                                # bytes(48)
+      8F6C7EC761691CAD374C4DAA9387453F18058ECE58EB0A8E
+      84A055A31FB7F9214B27509522C159E764F8711E11609554
+~~~
+
+The COSE thumbprint (in hexadecimal)--SHA256 hash of the thumbprint fields:
+
+~~~
+554550a611c9807b3462cfec4a690a1119bc43b571da1219782133f5fd6dbcb0
+~~~
 
 Issuer key pair in JWK format
 

--- a/sd-cwt-example.cbor-diag
+++ b/sd-cwt-example.cbor-diag
@@ -1,8 +1,8 @@
 / cose-sign1 / 18( / sd_kbt / [
     / KBT protected / << {
-        / alg / 1         : -7 / ES256 /,
+        / alg / 1         : -7, / ES256 /
         / typ / 16        : "application/kb+cwt",
-        / kcwt /        13: << 18([  / issuer SD-CWT /
+        / kcwt /        13:  18([  / issuer SD-CWT /
           / CWT protected / << {
             / alg /    1  : -35, / ES384 /
             / typ /    16 : "application/sd+cwt",
@@ -70,7 +70,7 @@
             }
           } >>,                    / end of issuer_sd_cwt payload /
           / CWT signature / h'3337af2e66959614'
-        ])>>,  / end of issuer SD-CWT /
+        ])     / end of issuer SD-CWT /
     }>>,     / end of KBT protected header
     / KBT unprotected / {},
     / KBT payload / << {

--- a/sd-cwts.cddl
+++ b/sd-cwts.cddl
@@ -24,7 +24,7 @@ sd-protected = {
 kbt-protected = {
    &(typ: 16) ^ => "application/kb+cwt",
    &(alg: 1) ^ => int,
-   &(kcwt: 13) ^ => bstr .cbor sd-cwt-issued,
+   &(kcwt: 13) ^ => sd-cwt-issued,
    * key => any   
 }
 


### PR DESCRIPTION
- Fix the kcwt format (it needs to be a CoseMessage (tagged or untagged), not a bstr encoding of one.
- Add COSE thumbprints for the holder and issuer to the examples in back

The "Automatic update" commits are from running `make update-files` (needed since GitHub deprecated v3 of their API)