### PR TITLE
removing double encoding WIP

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -354,7 +354,7 @@ decoy = [
 ]
 
 ; a collection of Salted Disclosed Claims
-salted-array = [ +bstr .cbor salted ]
+salted-array = [ +salted ]
 ~~~
 
 When a blinded claim is a key in a map, its blinded claim hash is added to a `redacted_claim_keys` array claim in the CWT payload that is at the same level of hierarchy as the key being blinded.

--- a/examples/sd-cwt.py
+++ b/examples/sd-cwt.py
@@ -103,8 +103,7 @@ def make_disclosure(salt=None, key=None, value=None):
         else:
             # map claim
             disclosure_array = [salt, key, value]
-    # double encode to add bstr type and bstr length
-    return cbor2.dumps(cbor2.dumps(disclosure_array))
+    return cbor2.dumps(disclosure_array)
 
 
 def parse_disclosures(disclosures):
@@ -316,14 +315,14 @@ def edn_one_disclosure(disclosure, comment=None):
     cmt = ""
     if comment != None:
         cmt = "   / " + comment + " /"
-    edn = '        <<[\n'
+    edn = '        [\n'
     edn += f"            /salt/   h'{bytes2hex(disclosure[0])}',\n"
     if len(disclosure) == 3:
         edn += f"            /claim/  {val(disclosure[1])},{cmt}\n"
         edn += f"            /value/  {val(disclosure[2])}\n"
     elif len(disclosure) == 2:
         edn += f"            /value/  {val(disclosure[1])}{cmt}\n"
-    edn += '        ]>>,\n'
+    edn += '        ],\n'
     return edn
 
 

--- a/sd-cwts.cddl
+++ b/sd-cwts.cddl
@@ -62,7 +62,7 @@ kbt-payload = {
     * key => any   
 }
 
-salted-array = [ +bstr .cbor salted ]
+salted-array = [ +salted ]
 salted = salted-claim / salted-element / decoy
 salted-claim = [
   bstr .size 16,     ; 128-bit salt


### PR DESCRIPTION
This PR is for discussion purposes.

The COSE protected headers and COSE payload are bstr encoded because they are used as inputs to a the signature function.
The disclosures are currently bstr encoded because they are used as inputs to the blinded hashes.

The WG could choose to stay with bstr encoding for consistency with COSE (any input to a crypto algorithm is bstr encoded), or we could eliminate one step of encoding. YMMV.