### PR TITLE
Apply clarifications and corrections resulting from reading the entire specification

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -158,7 +158,7 @@ Verifier:
 : An entity that validates a Partial or Full Disclosure by a Holder.
 
 Partial Disclosure:
-: When a subset of the original claims protected by the Issuer are disclosed by the Holder.
+: When a subset of the original claims, protected by the Issuer, are disclosed by the Holder.
 
 Full Disclosure:
 : When the full set of claims protected by the Issuer is disclosed by the Holder. An SD-CWT with no blinded claims (when all claims are marked as mandatory to disclose by the Issuer) is considered a Full Disclosure.

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -364,7 +364,6 @@ When blinding an individual item in an array, the value of the item is replaced 
 ~~~ cddl
 ; redacted_claim_element = #6.<TBD5>( bstr .size 16 ) -- RFC 9682 syntax
 redacted_claim_element = #6.60( bstr .size 16 )
-;; XXX is the digest always .size 16?
 ~~~
 
 Blinded claims can be nested. For example, both individual keys in the `inspection_location` claim, and the entire `inspection_location` element can be separately blinded.

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -275,7 +275,7 @@ Redacted claims that are array elements are handled slightly differently, as des
 ~~~
 {: title="redacted inspector_license_number claim in the issued CWT payload"}
 
-# Holder prepares an SD-CWT for a Verifier {#SD-CWT-preparation}
+# Holder prepares an SD-CWT for a Verifier {#sd-cwt-preparation}
 
 When the Holder wants to send an SD-CWT and disclose none, some, or all of the redacted values, it makes a list of the values to disclose and puts them in `sd_claims` header parameter in the unprotected header.
 
@@ -319,7 +319,7 @@ Variability in serialization requirements impacts privacy.
 See {{security}} for more details on the privacy impact of serialization and profiling.
 
 
-# SD-CWT Definition {#SD-CWT-def}
+# SD-CWT Definition {#sd-cwt-definition}
 
 SD-CWT is modeled after SD-JWT, with adjustments to align with conventions in CBOR, COSE, and CWT. An SD-CWT MUST include the protected header parameter `typ` {{!RFC9596}} with either the text value "application/sd+cwt" or an uint value of TBD11 in the SD-CWT.
 
@@ -373,10 +373,10 @@ Finally, an issuer MAY create decoy digests, which look like blinded claim hashe
 Decoy digests are discussed in {{decoys}}.
 
 
-# SD-CWT Issuance {#SD-CWT-issuance}
+# SD-CWT Issuance {#sd-cwt-issuance}
 
 How the Holder communicates to the Issuer to request a CWT or an SD-CWT is out of scope for this specification.
-Likewise, how the Holder determines which claims to blind or to always disclose is a policy matter that is not discussed in this specification.
+Likewise, how the Holder determines which claims to blind or to always disclose is a policy matter, which is not discussed in this specification.
 This specification defines the format of an SD-CWT communicated between an Issuer and a Holder in this section, and describes the format of a Key Binding Token containing that SD-CWT communicated between a Holder and a Verifier in {{sd-cwt-presentation}}.
 
 The protected header MUST contain the `sd_alg` header parameter identifying the algorithm (from the COSE Algorithms registry) used to hash the Salted Disclosed Claims.
@@ -586,7 +586,7 @@ When encrypted disclosures are present, they MUST be in the unprotected headers 
 
 The verifier of the key binding token might not be able to decrypt encrypted disclosures and MAY decide to forward them to an inner verifier that can decrypt them.
 
-## AEAD Encrypted Disclosures {#AEAD}
+## AEAD Encrypted Disclosures {#aead}
 
 This section defines two new COSE Header Parameters.
 If present in the protected headers, the first header parameter (`sd_aead`) specifies an IANA registered Authenticated Encryption with Additional Data (AEAD) algorithm {{!RFC5116}}.
@@ -970,7 +970,7 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: bstr
 * Value Registry: (empty)
 * Description: A list of selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-* Reference: {{SD-CWT-preparation}} of this specification
+* Reference: {{sd-cwt-preparation}} of this specification
 
 ### sd_alg
 
@@ -981,7 +981,7 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: int
 * Value Registry: IANA COSE Algorithms
 * Description: The hash algorithm used for redacting disclosures.
-* Reference: {{SD-CWT-issuance}} of this specification
+* Reference: {{sd-cwt-issuance}} of this specification
 
 ### sd_encrypted_claims
 
@@ -992,7 +992,7 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: bstr
 * Value Registry: (empty)
 * Description: A list of AEAD encrypted selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-* Reference: {{AEAD}} of this specification
+* Reference: {{aead}} of this specification
 
 ### sd_aead
 
@@ -1003,7 +1003,7 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: int
 * Value Registry: IANA AEAD Algorithm number
 * Description: The AEAD algorithm used for encrypting disclosures.
-* Reference: {{AEAD}} of this specification
+* Reference: {{aead}} of this specification
 
 ### sd_cose_encrypted_claims
 
@@ -1078,7 +1078,7 @@ The following completed registration template is provided:
 * Encoding considerations: binary
 * Security considerations: {{security}} of this specification and {{RFC8392}}
 * Interoperability considerations: n/a
-* Published specification: {{SD-CWT-def}} of this specification
+* Published specification: {{sd-cwt-definition}} of this specification
 * Applications that use this media type: TBD
 * Fragment identifier considerations: n/a
 * Additional information:
@@ -1126,7 +1126,7 @@ The following completed registration template is provided:
 IANA is requested to register the following entries in the "CoAP Content-Formats" registry within the "Constrained RESTful Environments (CoRE) Parameters" registry group {{!IANA.core-parameters}}:
 
 | Content-Type | Content Coding | ID | Reference |
-| application/sd+cwt | - | TBD11 | {{SD-CWT-def}} of this specification |
+| application/sd+cwt | - | TBD11 | {{sd-cwt-definition}} of this specification |
 | application/kb+cwt | - | TBD12 | {{kbt}} of this specification |
 {: align="left" title="New CoAP Content Formats"}
 
@@ -1176,7 +1176,7 @@ Because the entire SD-CWT is included as a claim in the SD-KBT, the disclosures 
 
 ## Validation
 
-The validation process for SD-CWT is similar to SD-JWT, however, JSON Objects are replaced with CBOR Maps that can contain integer keys and CBOR Tags.
+The validation process for SD-CWT is similar to SD-JWT, however, JSON Objects are replaced with CBOR Maps, which can contain integer keys and CBOR Tags.
 
 # Keys Used in the Examples
 

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -369,7 +369,7 @@ redacted_claim_element = #6.60( bstr .size 16 )
 Blinded claims can be nested. For example, both individual keys in the `inspection_location` claim, and the entire `inspection_location` element can be separately blinded.
 An example nested claim is shown in {{nesting}}.
 
-Finally, an issuer MAY create decoy digests that look like blinded claim hashes but have only a salt.
+Finally, an issuer MAY create decoy digests, which look like blinded claim hashes but have only a salt.
 Decoy digests are discussed in {{decoys}}.
 
 

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -68,35 +68,34 @@ informative:
     title: "t-Closeness: Privacy Beyond k-Anonymity and l-Diversity"
     date: 2007-06-04
 
-entity:
-  SELF: "RFCthis"
-
 --- abstract
 
-This document describes a data minimization technique for use with CBOR Web Token (CWT).
-The approach is based on Selective Disclosure JSON Web Token (SD-JWT), with changes to align with CBOR Object Signing and Encryption (COSE).
+This specification describes a data minimization technique for use with CBOR Web Tokens (CWTs).
+The approach is based on the Selective Disclosure JSON Web Token (SD-JWT), with changes to align with CBOR Object Signing and Encryption (COSE) and CWTs.
 
 
 --- middle
 
 # Introduction
 
-This document updates the CBOR Web Token (CWT) specification {{RFC8392}}, enabling the holder of a CWT to disclose or redact special claims marked disclosable by the issuer of a CWT.
-The approach is modeled after SD-JWT {{-SD-JWT}}, with changes to align with conventions from CBOR Object Signing and Encryption (COSE) {{RFC9052}}.
-This specification enables Holders of CWT based credentials to prove the integrity and authenticity of selected attributes asserted by an Issuer about a Subject to a Verifier.
-Although techniques such as one time use and batch issuance can improve the confidentiality and security characteristics of CWT based credential protocols, CWTs remain traceable.
+This specification updates the CBOR Web Token (CWT) specification {{RFC8392}}, enabling the holder of a CWT to disclose or redact special claims marked as selectively disclosable by the issuer of a CWT.
+The approach is modeled after SD-JWT {{-SD-JWT}}, with changes to align with conventions from CBOR Object Signing and Encryption (COSE) {{RFC9052}} and CWT.
+This specification enables Holders of CWT-based credentials to prove the integrity and authenticity of selected attributes asserted by an Issuer about a Subject to a Verifier.
+
+Although techniques such as one time use and batch issuance can improve the confidentiality and security characteristics of CWT-based credential protocols, CWTs remain traceable.
 Selective Disclosure CBOR Web Tokens (SD-CWTs) are CWTs and can be deployed in protocols that are already using CWTs, even if they contain no optional to disclose claims.
-Credential types are distinguished by their attributes, for example a license to operate a vehicle and a license to import a product will contain different attributes.
-The specification of credential types is out of scope for this document, and the examples used in this document are informative.
+Credential types are distinguished by their attributes, for example, a license to operate a vehicle and a license to import a product will contain different attributes.
+The specification of credential types is out of scope for this specification and the examples used in this specification are informative.
+
 SD-CWT operates on CWT Claims Sets as described in {{RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.
 SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a holder of a CWT to disclose.
-A holder cannot send redacted claim keys to a verifier who does not understand selective disclosure at all.
-However, Claim Keys and Claim Values which are not understood remain ignored as described in {{Section 3 of RFC8392}}.
+A verifier that does not understand selective disclosure at all cannot process redacted Claim Keys sent by the Holder.
+However, Claim Keys and Claim Values that are not understood remain ignored, as described in {{Section 3 of RFC8392}}.
 
-## High level flow
+## High-Level Flow
 
-Figure 1: High level SD-CWT Issuance and Presentation Flow
+Figure 1: High-level SD-CWT Issuance and Presentation Flow
 
 ~~~ aasvg
 Issuer                           Holder                         Verifier
@@ -125,8 +124,8 @@ Issuer                           Holder                         Verifier
 ~~~
 
 This diagram captures the essential details necessary to issue and present an SD-CWT.
-The parameters necessary to support these processes can be obtained using transports or protocols which are out of scope for this specification.
-However the following guidance is generally recommended, regardless of protocol or transport.
+The parameters necessary to support these processes can be obtained using transports or protocols that are out of scope for this specification.
+However, the following guidance is generally recommended, regardless of protocol or transport.
 
 1. The issuer SHOULD confirm the holder controls all confirmation material before issuing credentials using the `cnf` claim.
 2. To protect against replay attacks, the verifier SHOULD provide a nonce, and reject requests that do not include an acceptable nonce (cnonce). This guidance can be ignored in cases where replay attacks are mitigated at another layer.
@@ -136,33 +135,33 @@ However the following guidance is generally recommended, regardless of protocol 
 
 {::boilerplate bcp14-tagged}
 
-This document uses terms from CWT {{RFC8392}}, and COSE {{RFC9052}}
-{{!RFC9053}}.
+This specification uses terms from CWT {{!RFC8392}}, COSE {{!RFC9052}} {{!RFC9053}}
+and JWT {{!RFC7519}}.
 
-The terms Claim Name, Claim Key and Claim Value are defined in {{RFC8392}}.
+The terms Claim Name, Claim Key, and Claim Value are defined in {{RFC8392}}.
 
-This document defines the following new terms:
+This specification defines the following new terms:
 
 Selective Disclosure CBOR Web Token (SD-CWT):
 : A CWT with claims enabling selective disclosure with key binding.
 
 Selective Disclosure Key Binding Token (SD-CWT-KBT):
-: A CWT used to demonstrate possession of a confirmation method, associated to an SD-CWT.
+: A CWT used to demonstrate possession of a confirmation method, associated with an SD-CWT.
 
 Issuer:
 : An entity that produces a Selective Disclosure CBOR Web Token.
 
 Holder:
-: An entity that presents a Selective Disclosure CBOR Web Token which includes a Selective Disclosure Key Binding Token.
+: An entity that presents a Selective Disclosure CBOR Web Token that includes a Selective Disclosure Key Binding Token.
 
 Verifier:
-: An entity that validates a Partial or Full Disclosure by a holder.
+: An entity that validates a Partial or Full Disclosure by a Holder.
 
 Partial Disclosure:
-: When a subset of the original claims protected by the Issuer, are disclosed by the Holder.
+: When a subset of the original claims protected by the Issuer are disclosed by the Holder.
 
 Full Disclosure:
-: When the full set of claims protected by the Issuer, is disclosed by the Holder. An SD-CWT with no blinded claims (all claims are marked mandatory to disclose by the Issuer) is considered a Full Disclosure.
+: When the full set of claims protected by the Issuer is disclosed by the Holder. An SD-CWT with no blinded claims (when all claims are marked as mandatory to disclose by the Issuer) is considered a Full Disclosure.
 
 Salted Disclosed Claim:
 : A salted claim disclosed in the unprotected header of an SD-CWT.
@@ -171,7 +170,7 @@ Digested Salted Disclosed Claim / Blinded Claim Hash:
 : A hash digest of a Salted Disclosed Claim.
 
 Blinded Claim:
-: Any Redacted Claim Key or Redacted Claim Element which has been replaced in the
+: Any Redacted Claim Key or Redacted Claim Element that has been replaced in the
 CWT payload by a Blinded Claim Hash.
 
 Redacted Claim Key:
@@ -192,7 +191,7 @@ Validated Disclosed Claims Set:
 
 ## A CWT without Selective Disclosure
 
-Below is the payload of a standard CWT without selective disclosure.
+Below is the payload of a standard CWT not using selective disclosure.
 It consists of standard CWT claims, the holder confirmation key, and five specific custom claims. The payload is shown below in CBOR Extended Diagnostic
 Notation (EDN) {{!I-D.ietf-cbor-edn-literals}}. Note that some of the CWT claim map keys shown in the examples have been invented for this example and do not have registered integer keys.
 
@@ -228,14 +227,14 @@ Notation (EDN) {{!I-D.ietf-cbor-edn-literals}}. Note that some of the CWT claim 
 }
 ~~~
 
-The custom claims deal with attributes of an inspection of the subject: the pass/fail result, the inspection location, the license number of the inspector, and a list of date when the subject was inspected.
+The custom claims deal with attributes of an inspection of the subject: the pass/fail result, the inspection location, the license number of the inspector, and a list of dates when the subject was inspected.
 
 ## Holder gets an SD-CWT from the Issuer
 
 Alice would like to selectively disclose some of these (custom) claims to different verifiers.
 Note that some of the claims may not be selectively disclosable.
-In our next example the pass/fail status of the inspection, the most recent inspection date, and the country of the inspection will be fixed claims (always present in the SD-CWT).
-After the Holder requests an SD-CWT from the issuer, the issuer generates an SD-CWT as follows:
+In our next example, the pass/fail status of the inspection, the most recent inspection date, and the country of the inspection will be fixed claims (always present in the SD-CWT).
+After the Holder requests an SD-CWT from the issuer, the issuer generates the following SD-CWT:
 
 ~~~ cbor-diag
 {::include examples/issuer_cwt.edn}
@@ -243,7 +242,7 @@ After the Holder requests an SD-CWT from the issuer, the issuer generates an SD-
 {: #basic-issuer-cwt title="Issued SD-CWT with all disclosures"}
 
 
-Some of the claims are *redacted* in the payload. The corresponding *disclosure* is communicated in the unprotected header in the `sd_claims` key.
+Some of the claims are *redacted* in the payload. The corresponding *disclosure* is communicated in the unprotected header in the `sd_claims` header parameter.
 For example, the `inspector_license_number` claim is a Salted Disclosed Claim, consisting of a per-disclosure random salt, the claim name, and claim value.
 
 ~~~ cbor-diag
@@ -252,7 +251,7 @@ For example, the `inspector_license_number` claim is a Salted Disclosed Claim, c
 {: title="CBOR extended diagnostic notation representation of inspector_license_number disclosure"}
 
 
-This is represented in CBOR pretty printed formal as follows (end of line comments and spaces inserted for clarity):
+This is represented in CBOR pretty-printed format as follows (with end-of-line comments and spaces inserted for clarity):
 
 ~~~ cbor-pretty
 {::include examples/first-disclosure.pretty}
@@ -260,8 +259,8 @@ This is represented in CBOR pretty printed formal as follows (end of line commen
 {: title="CBOR encoding of inspector_license_number disclosure"}
 
 
-The SHA-256 hash (the hash algorithm identified in the `sd_alg` protected header field) of that byte string is the Digested Salted Disclosed Claim (in hex).
-The digest value is included in the payload in a `redacted_claim_keys` field for a Redacted Claim Key (in this example), or in a named array for a Redacted Claim Element (ex: for a redacted claim element of `inspection_dates`).
+The SHA-256 hash (the hash algorithm identified in the `sd_alg` header parameter of the protected headers) of that byte string is the Digested Salted Disclosed Claim (in hex).
+The digest value is included in the payload in a `redacted_claim_keys` field for a Redacted Claim Key (in this example), or in a named array for a Redacted Claim Element (for example, for the redacted claim element of `inspection_dates`).
 
 ~~~
 {::include examples/first-blinded-hash.txt}
@@ -269,16 +268,16 @@ The digest value is included in the payload in a `redacted_claim_keys` field for
 {: title="SHA-256 hash of inspector_license_number disclosure"}
 
 Finally, since this redacted claim is a map key and value, the Digested Salted Disclosed Claim is placed in a `redacted_claim_keys` array in the SD-CWT payload at the same level of hierarchy as the original claim.
-Redacted claims which are array elements are handled slightly differently, as described in {{types-of-blinded-claims}}.
+Redacted claims that are array elements are handled slightly differently, as described in {{blinded-claims}}.
 
 ~~~ cbor-diag
 {::include examples/first-redacted.edn}
 ~~~
 {: title="redacted inspector_license_number claim in the issued CWT payload"}
 
-# Holder prepares an SD-CWT for a Verifier
+# Holder prepares an SD-CWT for a Verifier {#SD-CWT-preparation}
 
-When the Holder wants to send an SD-CWT and disclose none, some, or all of the redacted values, it makes a list of the values to disclose and puts them in `sd_claims` in the unprotected header.
+When the Holder wants to send an SD-CWT and disclose none, some, or all of the redacted values, it makes a list of the values to disclose and puts them in `sd_claims` header parameter in the unprotected header.
 
 For example, Alice decides to disclose to a verifier the `inspector_license_number` claim (ABCD-123456), the `region` claim (California), and the earliest date element in the `inspection_dates` array (7-Feb-2019).
 
@@ -296,44 +295,44 @@ The issued SD-CWT is placed in the `kcwt` (Confirmation Key CWT) protected heade
 {::include examples/elided-kbt.edn}
 ~~~
 
-Together the digests in protected parts of the issued SD-CWT, and the disclosures hashed in unprotected header of the `issuer_sd_cwt` are used by the Verifier to confirm the disclosed claims.
-Since the unprotected header of the included SD-CWT is covered by the signature in the SW-KBT, the Verifier has assurance the Holder included the sent list of disclosures.
+The digests in protected parts of the issued SD-CWT and the disclosures hashed in unprotected header of the `issuer_sd_cwt` are used together by the Verifier to confirm the disclosed claims.
+Since the unprotected header of the included SD-CWT is covered by the signature in the SW-KBT, the Verifier has assurance that the Holder included the sent list of disclosures.
 
 # Update to the CBOR Web Token Specification {#cwt-update}
 
 The CBOR Web Token Specification (Section 1.1 of {{RFC8392}}), uses text strings, negative integers, and unsigned integers as map keys.
-This specification relaxes that requirement, by also allowing the CBOR simple value registered in this document in {{simple59}}, and CBOR tagged integers and text strings as map keys.
+This specification relaxes that requirement, by also allowing the CBOR simple value registered in this specification in {{simple59}}, and CBOR tagged integers and text strings as map keys.
 CBOR maps used in a CWT cannot have duplicate keys.
-(An integer or text string map key is a distinct key from a tagged map key which wraps the corresponding integer or text string value).
+(An integer or text string map key is a distinct key from a tagged map key that wraps the corresponding integer or text string value).
 
 >When sorted, map keys in CBOR are arranged in bytewise lexicographic order of the key's deterministic encodings (see Section 4.2.1 of {{RFC8949}}).
->So an integer key of 3 is represented in hex as `03`, an integer key of -2 is represented in hex as `21`, and a tag of 60 wrapping a 3 is represented in hex as `D8 3C 03`
+>So, an integer key of 3 is represented in hex as `03`, an integer key of -2 is represented in hex as `21`, and a tag of 60 wrapping a 3 is represented in hex as `D8 3C 03`
 
 Note that holders presenting to a verifier that does not support this specification would need to present a CWT without tagged map keys or simple value map keys.
 
 Tagged keys are not registered in the CBOR Web Token Claims IANA registry.
-Instead the tag provides additional information about the tagged claim key and the corresponding (untagged) value.
+Instead, the tag provides additional information about the tagged claim key and the corresponding (untagged) value.
 Multiple levels of tags in a key are not permitted.
 
 Variability in serialization requirements impacts privacy.
 
-See the security considerations section for more details on the privacy impact of serialization and profiling.
+See {{security}} for more details on the privacy impact of serialization and profiling.
 
 
-# SD-CWT definition
+# SD-CWT Definition {#SD-CWT-def}
 
-SD-CWT is modeled after SD-JWT, with adjustments to align with conventions in CBOR and COSE. An SD-CWT MUST include the protected header parameter `typ` {{!RFC9596}} with either a text value "application/sd-cwt" or an uint value of "C-F-TBD" in the SD-CWT.
+SD-CWT is modeled after SD-JWT, with adjustments to align with conventions in CBOR, COSE, and CWT. An SD-CWT MUST include the protected header parameter `typ` {{!RFC9596}} with either the text value "application/sd+cwt" or an uint value of TBD11 in the SD-CWT.
 
 An SD-CWT is a CWT that can contain blinded claims (each expressed as a Blinded Claim Hash) in the CWT payload, at the root level or in any arrays or maps inside that payload.
 It is not required to contain any blinded claims.
 
-Optionally the salted claim values (and often claim names) for the corresponding Blinded Claim Hash are actually disclosed in the `sd_claims` field in the unprotected header of the CWT (the disclosures).
-If there are no disclosures (and when no Blinded Claims Hash is present in the payload) the `sd_claims` field in the unprotected header is an empty array.
+Optionally the salted claim values (and often claim names) for the corresponding Blinded Claim Hash are disclosed in the `sd_claims` header parameter in the unprotected header of the CWT (the disclosures).
+If there are no disclosures (and when no Blinded Claims Hash is present in the payload) the `sd_claims` header parameter in the unprotected header is an empty array.
 
 Any party with a Salted Disclosed Claim can generate its hash, find that hash in the CWT payload, and unblind the content.
-However a Verifier with the hash cannot reconstruct the corresponding blinded claim without disclosure of the Salted Disclosed Claim.
+However, a Verifier with the hash cannot reconstruct the corresponding blinded claim without disclosure of the Salted Disclosed Claim.
 
-## Types of blinded claims
+## Types of Blinded Claims {#blinded-claims}
 
 Salted Disclosed Claims for named claims are structured as a 128-bit salt, the disclosed value, and the name of the redacted element.
 For Salted Disclosed Claims of items in an array, the name is omitted.
@@ -358,53 +357,54 @@ salted-array = [ +bstr .cbor salted ]
 ~~~
 
 When a blinded claim is a key in a map, its blinded claim hash is added to a `redacted_claim_keys` array claim in the CWT payload that is at the same level of hierarchy as the key being blinded.
-The `redacted_claim_keys` key is a CBOR simple type registered for that purpose (with the requested value of 59).
+The `redacted_claim_keys` key is the CBOR simple type TBD4 registered for that purpose (with the requested value of 59).
 
-When blinding an individual item in an array, the value of the item is replaced with the digested salted hash as a CBOR byte string, wrapped with a CBOR tag (requested tag number 60).
+When blinding an individual item in an array, the value of the item is replaced with the digested salted hash as a CBOR byte string, wrapped with the CBOR tag TBD5 (requested tag number 60).
 
 ~~~ cddl
 ; redacted_claim_element = #6.<TBD5>( bstr .size 16 ) -- RFC 9682 syntax
 redacted_claim_element = #6.60( bstr .size 16 )
-;; XXX is the digest alwats .size 16?
+;; XXX is the digest always .size 16?
 ~~~
 
 Blinded claims can be nested. For example, both individual keys in the `inspection_location` claim, and the entire `inspection_location` element can be separately blinded.
 An example nested claim is shown in {{nesting}}.
 
-Finally, an issuer may create "decoy digests" which look like a blinded claim hash but have only a salt.
+Finally, an issuer MAY create decoy digests that look like blinded claim hashes but have only a salt.
 Decoy digests are discussed in {{decoys}}.
 
 
-# SD-CWT Issuance
+# SD-CWT Issuance {#SD-CWT-issuance}
 
-How the Holder communicates to the Issuer to request a CWT or an SD-CWT is out-of-scope of this specification.
-Likewise, how the Holder determines which claims to blind or to always disclose is a policy matter which is not discussed in this specification.
+How the Holder communicates to the Issuer to request a CWT or an SD-CWT is out of scope for this specification.
+Likewise, how the Holder determines which claims to blind or to always disclose is a policy matter that is not discussed in this specification.
 This specification defines the format of an SD-CWT communicated between an Issuer and a Holder in this section, and describes the format of a Key Binding Token containing that SD-CWT communicated between a Holder and a Verifier in {{sd-cwt-presentation}}.
 
-The protected header MUST contain the `sd_alg` field identifying the algorithm (from the COSE Algorithms registry) used to hash the Salted Disclosed Claims.
-The unprotected header MUST contain an `sd_claims` section with a Salted Disclosed Claim for *every* blinded claim hash present anywhere in the payload, and any decoys (see {{decoys}}).
-If there are no disclosures, the `sd_claims` header is an empty array.
-The payload MUST also include a key confirmation element (`cnf`) {{!RFC8747}} for the Holder's public key.
+The protected header MUST contain the `sd_alg` header parameter identifying the algorithm (from the COSE Algorithms registry) used to hash the Salted Disclosed Claims.
+The unprotected header MUST contain the `sd_claims` header parameter with a Salted Disclosed Claim for every blinded claim hash present anywhere in the payload, and any decoys (see {{decoys}}).
+If there are no disclosures, the `sd_claims` header parameter value is an empty array.
+The payload also MUST include a key confirmation element (`cnf`) {{!RFC8747}} for the Holder's public key.
 
-In an SD-CWT, either the subject `sub`/ 2 claim is present, or the redacted form of the subject is present.
-The issuer `iss` / 1 standard claim SHOULD be present, unless the protected header contains a certificate or certificate-like entity which fully identifies the issuer.
-All other standard CWT claims (`aud`/ 3, `exp` / 4, `nbf` / 5, `iat` / 6, and `cti` / 7) are OPTIONAL.
+In an SD-CWT, either the subject `sub` / 2 claim MUST be present, or the redacted form of the subject MUST be present.
+The issuer `iss` / 1 claim SHOULD be present unless the protected header contains a certificate or certificate-like entity that fully identifies the issuer.
+All other standard CWT claims (`aud` / 3, `exp` / 4, `nbf` / 5, `iat` / 6, and `cti` / 7) are OPTIONAL.
 The `cnonce` / 39 claim is OPTIONAL.
-The `cnf` claim, the `cnonce` claim, and the standard claims other than the subject MUST NOT be redacted.
+The `cnf` / 8 claim, the `cnonce` / 39 claim, and the standard claims other than the subject MUST NOT be redacted.
 Any other claims are OPTIONAL and MAY be redacted.
+Profiles of this specification MAY specify additional claims that MUST, MUST NOT, and MAY be redacted.
 
 To further reduce the size of the SD-CWT, a COSE Key Thumbprint (ckt) {{!RFC9679}} MAY be used in the `cnf` claim.
 
 
-## Issuer generation
+## Issuer Generation
 
-The Issuer follows all the requirements of generating a valid CWT as updated by {{cwt-update}}.
-The Issuer MUST implement COSE_Sign1 using an appropriate asymmetric signature algorithm / curve combination (for example ES256/P-256 or EdDSA/Ed25519)
+The Issuer follows all the requirements of generating a valid CWT, as updated by {{cwt-update}}.
+The Issuer MUST implement COSE_Sign1 using an appropriate fully-specified asymmetric signature algorithm (for example, ESP256 or Ed25519).
 
 The Issuer MUST generate a unique cryptographically random salt with at least 128-bits of entropy for each Salted Disclosed Claim.
-If the client communicates a client-generated nonce (`cnonce`) when requesting the SD-CWT, the Issuer SHOULD include it in the payload.
+If the client communicates a client-generated nonce (`cnonce`) when requesting the SD-CWT, the Issuer MUST include it in the payload.
 
-## Holder validation
+## Holder Validation
 
 Upon receiving an SD-CWT from the Issuer with the Holder as the subject, the
 Holder verifies the following:
@@ -413,13 +413,13 @@ Holder verifies the following:
 - if an audience (`aud`) is present, it is acceptable;
 - the CWT is valid according to the `nbf` and `exp` claims, if present;
 - a public key under the control of the Holder is present in the `cnf` claim;
-- the hash algorithm in the `sd_alg` protected header is supported by the Holder;
-- if a `cnonce` is present, it was provided by the Holder to this Issuer and is still "fresh";
-- there are no unblinded claims about the subject which violate its privacy policies;
+- the hash algorithm in the `sd_alg` header parameter in the protected headers is supported by the Holder;
+- if a `cnonce` is present, it was provided by the Holder to this Issuer and is still fresh;
+- there are no unblinded claims about the subject that violate its privacy policies;
 - every blinded claim hash (some of which may be nested as in {{nesting}}) has a corresponding Salted Disclosed Claim, and vice versa;
 - all the Salted Disclosed Claims are correct in their unblinded context in the payload.
 
-The following informative CDDL is provided to describe the syntax for an SD-CWT issuance. A complete CDDL schema is in {{cddl}}.
+The following informative CDDL is provided to describe the syntax for SD-CWT issuance. A complete CDDL schema is in {{cddl}}.
 
 ~~~ cddl
 sd-cwt-issued = #6.18([
@@ -465,9 +465,9 @@ sd-payload = {
 # SD-CWT Presentation
 
 When a Holder presents an SD-CWT to a Verifier, it can disclose none, some, or all of its blinded claims.
-If the Holder wishes to disclose any claims, it includes that subset of its Salted Disclosed Claims in the `sd_claims` claim of the unprotected header.
+If the Holder wishes to disclose any blinded claims, it includes that subset of its Salted Disclosed Claims in the `sd_claims` header parameter of the unprotected header.
 
-An SD-CWT presentation to a Verifier has the same syntax as an SD-CWT issued to a Holder, except the Holder chooses the subset of disclosures included in the `sd_claims` claim.
+An SD-CWT presentation to a Verifier has the same syntax as an SD-CWT issued to a Holder, except the Holder chooses the subset of disclosures included in the `sd_claims` header parameter.
 Since the unprotected header is not included in the signature, it will contain all the Salted Disclosed Claims when sent from the Issuer to the Holder.
 When sent from the Holder to the Verifier, the unprotected header will contain none, some, or all of these Claims.
 Finally, the SD-CWT used for presentation to a Verifier is included in a key binding token, as discussed in the next section.
@@ -480,12 +480,12 @@ An SD-KBT is itself a type of CWT, signed using the private key corresponding to
 The SD-KBT contains the SD-CWT, including the Holder's choice of presented disclosures, in the `kcwt` protected header field in the SD-KBT.
 
 The Holder is conceptually both the subject and the issuer of the Key Binding Token.
-Therefore the `sub` and `iss` of an SD-KBT are implied from the `cnf` claim in the included SD-CWT, and are ignored for validation purposes if they are present.
-(A profile may define additional semantics.)
+Therefore, the `sub` and `iss` of an SD-KBT are implied from the `cnf` claim in the included SD-CWT, and are ignored for validation purposes if they are present.
+(Profiles of this specification MAY define additional semantics.)
 
-The `aud` claim MUST be included and relevant to the Verifier.
-The SD-KBT payload MUST contain the issued_at (`iat`) claims.
-The protected header of the SD-KBT MUST include the `typ` header parameter with the value `application/sd-kbt`.
+The `aud` claim MUST be included and MUST correspond to the Verifier.
+The SD-KBT payload MUST contain the `iat` (issued at) claim.
+The protected header of the SD-KBT MUST include the `typ` header parameter with the value `application/sd+kbt` or an uint value of TBD12.
 
 The SD-KBT provides the following assurances to the Verifier:
 
@@ -495,7 +495,7 @@ The SD-KBT provides the following assurances to the Verifier:
 - the Holder's disclosure is linked to the creation time (`iat`) of the key binding.
 
 The SD-KBT prevents an attacker from copying and pasting disclosures, or from adding or removing disclosures without detection.
-Confirmation is established according to RFC 8747, using the `cnf` claim in the payload of the SD-CWT.
+Confirmation is established according to {{!RFC8747}}, using the `cnf` claim in the payload of the SD-CWT.
 
 The Holder signs the SD-KBT using the key specified in the `cnf` claim in the SD-CWT. This proves possession of the Holder's private key.
 
@@ -537,13 +537,13 @@ All other claims are OPTIONAL in an SD-KBT.
 
 The exact order of the following steps MAY be changed, as long as all checks are performed before deciding if an SD-CWT is valid.
 First the Verifier must open the protected headers of the SD-KBT and find the issuer SD-CWT present in the `kcwt` field.
-Next the Verifier must validate the SD-CWT as described in {{Section 7.2 of RFC8392}}.
-The Verifier extract the confirmation key from the `cnf` claim in the SD-CWT payload.
+Next, the Verifier must validate the SD-CWT as described in {{Section 7.2 of RFC8392}}.
+The Verifier extracts the confirmation key from the `cnf` claim in the SD-CWT payload.
 Using the confirmation key, the Verifier validates the SD-KBT as described in {{Section 7.2 of RFC8392}}.
 
-Finally, the Verifier MUST extract and decode the disclosed claims from the `sd_claims` in the unprotected header of the SD-CWT.
-The decoded `sd_claims` are converted to an intermediate data structure called a Digest To Disclosed Claim Map which is used to transform the Presented Disclosed Claimset, into a Validated Disclosed Claimset.
-The Verifier MUST compute the hash of each Salted Disclosed Claim (`salted`), in order to match each disclosed value to each entry of the Presented Disclosed Claimset.
+Finally, the Verifier MUST extract and decode the disclosed claims from the `sd_claims` header parameter in the unprotected header of the SD-CWT.
+The decoded `sd_claims` are converted to an intermediate data structure called a Digest To Disclosed Claim Map that is used to transform the Presented Disclosed Claims Set into a Validated Disclosed Claims Set.
+The Verifier MUST compute the hash of each Salted Disclosed Claim (`salted`), in order to match each disclosed value to each entry of the Presented Disclosed Claims Set.
 
 One possible concrete representation of the intermediate data structure for the Digest To Disclosed Claim Map could be:
 
@@ -553,17 +553,17 @@ One possible concrete representation of the intermediate data structure for the 
 }
 ~~~
 
-The Verifier constructs an empty cbor map called the Validated Disclosed Claimset, and initializes it with all mandatory to disclose claims from the verified Presented Disclosed Claimset.
-Next the Verifier performs a breadth first or depth first traversal of the Presented Disclosed Claimset, Validated Disclosed Claimset, using the Digest To Disclosed Claim Map to insert claims into the Validated Disclosed Claimset when they appear in the Presented Disclosed Claimset.
+The Verifier constructs an empty cbor map called the Validated Disclosed Claims Set, and initializes it with all mandatory to disclose claims from the verified Presented Disclosed Claims Set.
+Next, the Verifier performs a breadth first or depth first traversal of the Presented Disclosed Claims Set and Validated Disclosed Claims Set, using the Digest To Disclosed Claim Map to insert claims into the Validated Disclosed Claims Set when they appear in the Presented Disclosed Claims Set.
 By performing these steps, the recipient can cryptographically verify the integrity of the protected claims and verify they have not been tampered with.
-If there remain unused claims in the Digest To Disclosed Claim Map at the end of this procedure the SD-CWT MUST be considered invalid, as if the signature had failed to verify.
+If there remain unused claims in the Digest To Disclosed Claim Map at the end of this procedure the SD-CWT MUST be considered invalid.
 
 > Note: A verifier MUST be prepared to process disclosures in any order. When disclosures are nested, a disclosed value could appear before the disclosure of its parent.
 
-A verifier MUST reject the SD-CWT if the audience claim in either the SD-CWT or the SD-KBT contains a value that is not recognized.
+A verifier MUST reject the SD-CWT if the audience claim in either the SD-CWT or the SD-KBT contains a value that does not correspond to the intended recipient.
 
-Otherwise the SD-CWT is considered valid, and the Validated Disclosed Claimset is now a CWT Claimset with no claims marked for redaction.
-Further validation logic can be applied to the Validated Disclosed Claimset, as it might normally be applied to a validated CWT claimset.
+Otherwise, the SD-CWT is considered valid, and the Validated Disclosed Claims Set is now a CWT Claims Set with no claims marked for redaction.
+Further validation logic can be applied to the Validated Disclosed Claims Set, just as it might be applied to a validated CWT Claims Set.
 
 # Decoy Digests {#decoys}
 
@@ -571,7 +571,7 @@ Further validation logic can be applied to the Validated Disclosed Claimset, as 
 
 # Encrypted Disclosures
 
-Some uses of SD-CWT involve verifiers which have internal structure.
+Some uses of SD-CWT involve verifiers that have internal structure.
 In these cases, encrypted disclosures allow more fine-grained disclosure inside a single presentation.
 
 > In the Remote Attestation Procedures (RATS) architecture {{?RFC9334}}, an SD-CWT is a RATS conceptual message that represents evidence.
@@ -581,13 +581,13 @@ In these cases, encrypted disclosures allow more fine-grained disclosure inside 
 
 > In the Messaging Layer Security (MLS) protocol {{?RFC9420}}, an SD-CWT credential {{?I-D.mahy-mls-sd-cwt-credential}} could present one subset of its disclosures to the MLS Distribution Service, and a different subset of those disclosures to the other members of the MLS group.
 
-The entire SD-CWT is included in the protected header of the SD-KBT, which secured the entire issuer signed SD-CWT including its unprotected headers which include its disclosures.
+The entire SD-CWT is included in the protected header of the SD-KBT, which secured the entire issuer signed SD-CWT including its unprotected headers that include its disclosures.
 
-When encrypted disclosures are present they MUST be in the unprotected header of the issuer signed SD-CWT, before the SD-KBT can be generated by the holder.
+When encrypted disclosures are present, they MUST be in the unprotected headers of the issuer signed SD-CWT, before the SD-KBT can be generated by the holder.
 
-The verifier of the key binding token, MAY not be able to decrypt encrypted disclosures, and MAY decide to forward them to an inner verifier that can decrypt them.
+The verifier of the key binding token might not be able to decrypt encrypted disclosures and MAY decide to forward them to an inner verifier that can decrypt them.
 
-## AEAD Encrypted Disclosures
+## AEAD Encrypted Disclosures {#AEAD}
 
 This section defines two new COSE Header Parameters.
 If present in the protected headers, the first header parameter (`sd_aead`) specifies an IANA registered Authenticated Encryption with Additional Data (AEAD) algorithm {{!RFC5116}}.
@@ -601,9 +601,9 @@ Taking the first example disclosure from above:
 The corresponding bstr is encrypted with an AEAD algorithm {{!RFC5116}}.
 If present, the algorithm of the `sd_aead` protected header field is used, or AEAD_AES_128_GCM if no algorithm was specified. The bstr is encrypted with a unique, random 16-octet nonce.
 The nonce (`nonce`), and the resulting `ciphertext` and `mac` are put in an array.
-The resulting array is placed in the `sd_encrypted_claims` unprotected header field array of the SD-CWT.
+The resulting array is placed in the `sd_encrypted_claims` header parameter in the unprotected headers of the SD-CWT.
 
-> The encryption mechanism in *this* section uses AEAD directly instead of COSE encryption, because AEAD is more broadly applicable to some of the other protocols in which encrypted disclosures might be used.
+> The encryption mechanism in this section uses the AEAD algorithm directly instead of COSE encryption, because AEAD is more broadly applicable to some of the other protocols in which encrypted disclosures might be used.
 
 ~~~ cbor-diag
 / sd_encrypted_claims / 19 : [ / encrypted disclosures /
@@ -618,15 +618,15 @@ The resulting array is placed in the `sd_encrypted_claims` unprotected header fi
 ]
 ~~~
 
-> In the example above the key in hex is `a061c27a3273721e210d031863ad81b6`.
+> In the example above, the key in hex is `a061c27a3273721e210d031863ad81b6`.
 
 The blinded claim hash is still over the unencrypted disclosure.
-The receiver of an encrypted disclosure, locates the appropriate key by looking up the mac.
-If the verifier is able to decrypt and verify an encrypted disclosure, the decrypted disclosure is then processed as if it where in the `sd_claims` unprotected header in the SD-CWT.
+The receiver of an encrypted disclosure locates the appropriate key by looking up the mac.
+If the verifier is able to decrypt and verify an encrypted disclosure, the decrypted disclosure is then processed as if it were in the `sd_claims` header parameter in the unprotected headers of the SD-CWT.
 
-Details of key management are left to the specific protocols which make use of encrypted disclosures.
+Details of key management are left to the specific protocols that make use of encrypted disclosures.
 
-The CDDL for encrypted disclosures is described below.
+The CDDL for encrypted disclosures is below.
 
 ~~~ cddl
 encrypted-array = [ +encrypted ]
@@ -639,11 +639,11 @@ encrypted = [
 ;bstr-encoded-salted = bstr .cbor salted
 ~~~
 
-> Note: because the algorithm is in a registry which contains only AEAD algorithms, an attacker cannot replace the algorithm or the message, without a decryption verification failure.
+> Note: Because the algorithm is in a registry that contains only AEAD algorithms, an attacker cannot replace the algorithm or the message, without a decryption verification failure.
 
-## COSE Encrypted Disclosures
+## COSE Encrypted Disclosures {#cose-encrypted}
 
-This section defines the new COSE Header Parameter (`sd_code_encrypted_claims`) which contains a list of tagged COSE_Encrypt0 or COSE_Encrypt encrypted disclosures, following the rules defined in {{!RFC9502}}.
+This section defines the new COSE Header Parameter (`sd_cose_encrypted_claims`) that contains a list of tagged COSE_Encrypt0 or COSE_Encrypt encrypted disclosures, following the rules defined in {{!RFC9502}}.
 
 Its contents have the same semantics as the AEAD encrypted disclosures in the previous section.
 
@@ -667,20 +667,20 @@ Taking the bstr encoding of the example disclosure in the previous section as th
 ]
 ~~~
 
-The CDDL for COSE encrypted disclosures is described below:
+The CDDL for COSE encrypted disclosures is below:
 
 ~~~ cddl
 cose-encrypted-array = [ +cose-encrypted ]
 cose-encrypted = COSE_Encrypt0_Tagged / COSE_Encrypt_Tagged
 ~~~
 
-The IANA COSE Algorithms registry contains many deprecated and unsafe algorithms.
-Implementations using COSE encrypted disclosures MUST select only encryption algorithms, and SHOULD only use algorithms that have a Yes in the Recommended column of the IANA COSE Algorithms registry.
+The IANA COSE Algorithms registry contains deprecated and unsafe algorithms.
+Implementations using COSE encrypted disclosures MUST select only fully-specified signature algorithms, authenticated encryption (AEAD) algorithms, and SHOULD preferably use algorithms that have a "Yes" in the "Recommended" column of the IANA COSE Algorithms registry.
 
 
-# Credential Types
+# Credential Types {#cred-types}
 
-This specification defines the CWT claim vct (for verifiable credential type). The vct value MUST be a case-sensitive StringOrURI (see {{RFC7519}}) value serving as an identifier for the type of the SD-CWT claimset. The vct value MUST be a Collision-Resistant Name as defined in Section 2 of {{RFC7515}}.
+This specification defines the CWT claim `vct` (for verifiable credential type). The vct value MUST be a case-sensitive StringOrURI (see {{RFC7519}}) value serving as an identifier for the type of the SD-CWT Claims Set. The `vct` value MUST be a Collision-Resistant Name, as defined in Section 2 of {{!RFC7515}}.
 
 This claim is defined for COSE based verifiable credentials, similar to the JOSE based verifiable credentials claim (`vct`) described in Section 3.2.2.1.1 of {{-SD-JWT-VC}}.
 
@@ -689,7 +689,7 @@ Profiles built on this specification are also encouraged to use more specific me
 
 # Examples
 
-## Minimal spanning example
+## Minimal Spanning Example
 
 The following example contains claims needed to demonstrate redaction of key-value pairs and array elements.
 
@@ -699,9 +699,9 @@ The following example contains claims needed to demonstrate redaction of key-val
 {: #example-edn title="An EDN Example"}
 
 
-## Nested example {#nesting}
+## Nested Example {#nesting}
 
-Instead of the structure from the previous example, imagine the payload contains an inspection history log with the following structure. It could be blinded at multiple levels of the claim set hierarchy.
+Instead of the structure from the previous example, imagine that the payload contains an inspection history log with the following structure. It could be blinded at multiple levels of the claims set hierarchy.
 
 ~~~ cbor-diag
 {
@@ -828,7 +828,7 @@ Verifiers start unblinding claims for which they have blinded claim hashes. They
 ]
 ~~~
 
-After applying the disclosures of the nested structure above, the disclosed claim set visible to the verifier would look like the following:
+After applying the disclosures of the nested structure above, the disclosed Claims Set visible to the verifier would look like the following:
 
 ~~~ cbor-diag
 {
@@ -861,78 +861,28 @@ After applying the disclosures of the nested structure above, the disclosed clai
 ~~~
 
 
-# Implementation Status
-
-Note to RFC Editor: Please remove this section as well as references to {{BCP205}} before AUTH48.
-
-This section records the status of known implementations of the protocol defined by this specification at the time of posting of this Internet-Draft, and is based on a proposal described in {{BCP205}}.
-The description of implementations in this section is intended to assist the IETF in its decision processes in progressing drafts to RFCs.
-Please note that the listing of any individual implementation here does not imply endorsement by the IETF.
-Furthermore, no effort has been spent to verify the information presented here that was supplied by IETF contributors.
-This is not intended as, and must not be construed to be, a catalog of available implementations or their features.
-Readers are advised to note that other implementations may exist.
-
-According to {{BCP205}}, "this will allow reviewers and working groups to assign due consideration to documents that have the benefit of running code, which may serve as evidence of valuable experimentation and feedback that have made the implemented protocols more mature.
-It is up to the individual working groups to use this information as they see fit".
-
-## Transmute Prototype
-
-Organization: Transmute Industries Inc
-
-Name: [github.com/transmute-industries/sd-cwt](https://github.com/transmute-industries/sd-cwt)
-
-Description: An open source implementation of this draft.
-
-Maturity: Prototype
-
-Coverage: The current version ('main') implements functionality similar to that described in this document, and will be revised, with breaking changes to support the generation of example data to support this specification.
-
-License: Apache-2.0
-
-Implementation Experience: No interop testing has been done yet. The code works as proof of concept, but is not yet production ready.
-
-Contact: Orie Steele (orie@transmute.industries)
-
-## Rust Prototype
-
-Organization: SimpleLogin
-
-Name: [github.com/beltram/esdicawt](https://github.com/beltram/esdicawt)
-
-Description: An open source Rust implementation of this draft in Rust.
-
-Maturity: Prototype
-
-Coverage: The current version is close to the spec with the exception of `redacted_claim_keys` using a CBOR SimpleValue as label instead of a tagged key. Not all the verifications have been implemented yet.
-
-License: Apache-2.0
-
-Implementation Experience: No interop testing has been done yet. The code works as proof of concept, but is not yet production ready.
-
-Contact: Beltram Maldant (beltram.ietf.spice@pm.me)
-
-# Security Considerations
+# Security Considerations {#security}
 
 Security considerations from COSE {{RFC9052}} and CWT {{RFC8392}} apply to this specification.
 
 ## Transparency
 
-Verification of an SD-CWT requires that the verifier have access to a verification key (public key) that is associated with the issuer.
-Compromise of the issuer's signing key enables an attacker to forge credentials for any subject associated with the issuer.
-Certificate transparency as described in {{-CT}}, or key transparency as described in {{-KT}} can enable the observation of incorrectly issued certificates or fraudulent bindings between verification keys and issuer identifiers.
-Issuers choose which claims to include in an SD-CWT, and whether they are mandatory to disclose, including self asserted claims such as "iss".
-All mandatory to disclose data elements are visible to the verifier as part of verification, some of these elements reveal information about the issuer, such as key or certificate thumbprints, supported digital signature algorithms, or operational windows which can be inferred from analysis of timestamps.
+Verification of an SD-CWT requires that the verifier have access to a verification key (public key) associated with the issuer.
+Compromise of the issuer's signing key would enable an attacker to forge credentials for any subject associated with the issuer.
+Certificate transparency, as described in {{-CT}}, or key transparency, as described in {{-KT}}, can enable the observation of incorrectly issued certificates or fraudulent bindings between verification keys and issuer identifiers.
+Issuers choose which claims to include in an SD-CWT, and whether they are mandatory to disclose, including self-asserted claims such as "iss".
+All mandatory to disclose data elements are visible to the verifier as part of verification. Some of these elements reveal information about the issuer, such as key or certificate thumbprints, supported digital signature algorithms, and operational windows that can be inferred from analysis of timestamps.
 
-## Traceability
+## Correlation
 
 Presentations of the same SD-CWT to multiple verifiers can be correlated by matching on the signature component of the COSE_Sign1.
-Signature based linkability can be mitigated by leveraging batch issuance of single use tokens, for a credential management complexity cost.
-Any claim value with sufficiently low "anonymity set" can be used track the subject.
-For example, a high precision issuance time might match the issuance of only a few credentials for a given issuer, and as such any presentation of a credential issued at that time can be determined to be associated with the set of credentials issued at that time, for those subjects.
+Signature based linkability can be mitigated by leveraging batch issuance of single-use tokens, at a credential management complexity cost.
+Any claim value with sufficiently low "anonymity set" can be used to track the subject.
+For example, a high precision issuance time might match the issuance of only a few credentials for a given issuer, and as such, any presentation of a credential issued at that time can be determined to be associated with the set of credentials issued at that time, for those subjects.
 
 ## Credential Types
 
-The mandatory and optional to disclose data elements in an SD-CWT are credential type specific.
+The mandatory- and optional-to-disclose data elements in an SD-CWT are credential type specific.
 Several distinct credential types might be applicable to a given use case.
 Issuers MUST perform a privacy and confidentiality assessment regarding each credential type they intend to issue prior to issuance.
 
@@ -944,17 +894,17 @@ The construction of such profiles has a significant impact on the privacy proper
 
 ## Threat Model
 
-Each use case will have a unique threat model which MUST be considered before the applicability of SD-CWT based credential types can be determined.
-This section provides a non exhaustive list of topics to be considered when developing a threat model for applying SD-CWT to a given use case.
+Each use case will have a unique threat model that MUST be considered before the applicability of SD-CWT-based credential types can be determined.
+This section provides a non-exhaustive list of topics to be considered when developing a threat model for applying SD-CWT to a given use case.
 
-Has there been a t-closeness, k-anonymity and l-diverity assessment (see {{t-Closeness}}) assuming compromise of the one or more issuers, verifiers or holders, for all relevant credential types?
+Has there been a t-closeness, k-anonymity, and l-diversity assessment (see {{t-Closeness}}) assuming compromise of the one or more issuers, verifiers or holders, for all relevant credential types?
 
 How many issuers exist for the credential type?
 Is the size of the set of issuers growing or shrinking over time?
 For a given credential type, will subjects be able to hold instances of the same credential type from multiple issuers, or just a single issuer?
 Does the credential type require or offer the ability to disclose a globally unique identifier?
-Does the credential type require high precision time or other claims that have sufficient entropy such that they can serve as a unique fingerprint for a specific subject.
-Does the credential type contain Personally Identifiable Information (PII), or other sensitive information which might have value in a market.
+Does the credential type require high precision time or other claims that have sufficient entropy such that they can serve as a unique fingerprint for a specific subject?
+Does the credential type contain Personally Identifiable Information (PII), or other sensitive information that might have value in a market?
 
 How many verifiers exist for the credential type?
 Is the size of the set of verifiers growing or shrinking over time?
@@ -965,7 +915,7 @@ Assuming multiple verifiers are simultaneously compromised, what knowledge regar
 
 How many subjects exist for the credential type?
 Is the size of the set of subjects growing or shrinking over time?
-Does the credential type require specific hardware, or algorithms that limit the set of possible subjects to owners of a specific device or subscribers to a given service.
+Does the credential type require specific hardware, or algorithms that limit the set of possible subjects to owners of specific devices or subscribers to specific services?
 
 ## Random Numbers
 
@@ -978,18 +928,18 @@ The issuer claim in the SD-CWT is self-asserted by the issuer.
 
 Because confirmation is mandatory, the subject claim of an SD-CWT, when present, is always related directly to the confirmation claim.
 There might be many subject claims and many confirmation keys that identify the same entity or that are controlled by the same entity, while the identifiers and keys are distinct values.
-Reusing an identifier or key enables traceability, but MUST be evaluated in terms of the confidential and privacy constraints associated with the credential type.
+Reusing an identifier or key enables correlation, but MUST be evaluated in terms of the confidential and privacy constraints associated with the credential type.
 Conceptually, the Holder is both the issuer and the subject of the SD-KBT, even if the issuer or subject claims are not present.
 If they are present, they are self-asserted by the Holder.
 All three are represented by the confirmation (public) key in the SD-CWT.
 
 As with any self-assigned identifiers, Verifiers need to take care to verify that the SD-KBT issuer and subject claims match the subject in the SD-KBT, and are a valid representation of the Holder and correspond to the Holder's confirmation key.
 Extra care should be taken in case the SD-CWT subject claim is redacted.
-Likewise, Holders and Verifiers need to verify that the issuer claim of the SD-CWT corresponds to the Issuer and the key described in the protected header of the SD-CWT.
+Likewise, Holders and Verifiers MUST verify that the issuer claim of the SD-CWT corresponds to the Issuer and the key described in the protected header of the SD-CWT.
 
 ## Covert Channels
 
-Any data element that is supplied by the issuer, and that appears random to the holder might be used to produce a covert channel, between the issuer and the verifier.
+Any data element that is supplied by the issuer, and that appears random to the holder might be used to produce a covert channel between the issuer and the verifier.
 The ordering of claims, and precision of timestamps can also be used to produce a covert channel.
 This is more of a concern for SD-CWT than typical CWTs, because the holder is usually considered to be aware of the issuer claims they are disclosing to a verifier.
 
@@ -1003,14 +953,14 @@ However, the order can affect the runtime of the verification process.
 ## Audience
 
 If the audience claim is present in both the SD-CWT and the SD-KBT, they are not required to be the same.
-SD-CWTs with an unrecognized audience claim are rejected, to protect against accidental disclosure of sensitive data.
+SD-CWTs with audience claims that do not correspond to the intended recipients MUST be rejected, to protect against accidental disclosure of sensitive data.
 
 
 # IANA Considerations
 
 ## COSE Header Parameters
 
-IANA is requested to add the following entries to the CWT claims registry (https://www.iana.org/assignments/cose/cose.xhtml#header-parameters).
+IANA is requested to add the following entries to the IANA "COSE Header Parameters" registry (https://www.iana.org/assignments/cose/cose.xhtml#header-parameters):
 
 ### sd_claims
 
@@ -1021,7 +971,7 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: bstr
 * Value Registry: (empty)
 * Description: A list of selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-* Reference: RFC XXXX
+* Reference: {{SD-CWT-preparation}} of this specification
 
 ### sd_alg
 
@@ -1032,18 +982,18 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: int
 * Value Registry: IANA COSE Algorithms
 * Description: The hash algorithm used for redacting disclosures.
-* Reference: RFC XXXX
+* Reference: {{SD-CWT-issuance}} of this specification
 
 ### sd_encrypted_claims
 
 The following completed registration template per RFC8152 is provided:
 
-* Name: sd_encrypted claims
+* Name: sd_encrypted_claims
 * Label: TBD6 (requested assignment 19)
 * Value Type: bstr
 * Value Registry: (empty)
 * Description: A list of AEAD encrypted selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-* Reference: RFC XXXX
+* Reference: {{AEAD}} of this specification
 
 ### sd_aead
 
@@ -1054,53 +1004,53 @@ The following completed registration template per RFC8152 is provided:
 * Value Type: int
 * Value Registry: IANA AEAD Algorithm number
 * Description: The AEAD algorithm used for encrypting disclosures.
-* Reference: RFC XXXX
+* Reference: {{AEAD}} of this specification
 
 ### sd_cose_encrypted_claims
 
 The following completed registration template per RFC8152 is provided:
 
-* Name: sd_cose_encrypted claims
+* Name: sd_cose_encrypted_claims
 * Label: TBD8 (requested assignment 21)
 * Value Type: bstr
 * Value Registry: (empty)
 * Description: A list of COSE encrypted selectively disclosed claims, which were originally redacted, then later disclosed at the discretion of the sender.
-* Reference: RFC XXXX
+* Reference: {{cose-encrypted}} of this specification
 
 
 ## CBOR Simple Values {#simple59}
 
-This document requests the assignment of the simple value described below.
+IANA is requested to add the following entry to the IANA "CBOR Simple Values" registry (https://www.iana.org/assignments/cbor-simple-values):
 
 * Value: TBD4 (requested assignment 59)
 * Semantics: This value as a map key indicates that the claim value is an array of redacted claim keys at the same level as the map key.
-* Specification Document(s): RFC XXXX
+* Specification Document(s): {{blinded-claims} of this specification
 
 ## CBOR Tags
 
-### To be redacted tag
+IANA is requested to add the following entries to the IANA "CBOR Tags" registry (https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml):
+
+### To Be Redacted Tag
 
 The array claim element, or map key and value inside the "To be redacted" tag is intended to be redacted using selective disclosure.
 
 * Tag: TBD3 (requested assignment 58)
 * Data Item: (any)
 * Semantics: An array claim element, or map key and value intended to be redacted.
-* Specification Document(s): RFC XXXX
+* Specification Document(s): {{blinded-claims} of this specification
 
-### Redacted claim element tag
+### Redacted Claim Element Tag
 
 The byte string inside the tag is a selective disclosure redacted claim element of an array.
 
 * Tag: TBD5 (requested assignment 60)
 * Data Item: byte string
 * Semantics: A selective disclosure redacted (array) claim element.
-* Specification Document(s): RFC XXXX
+* Specification Document(s): {{blinded-claims} of this specification
 
 ## CBOR Web Token (CWT) Claims
 
-IANA is requested to add the following entries to the CWT claims registry (https://www.iana.org/assignments/cwt/cwt.xhtml).
-
-<!-- https://datatracker.ietf.org/doc/html/draft-ietf-oauth-selective-disclosure-jwt-12#name-json-web-token-claims-regis -->
+IANA is requested to add the following entry to the IANA "CWT Claims" registry (https://www.iana.org/assignments/cwt/cwt.xhtml):
 
 ### vct
 
@@ -1112,15 +1062,13 @@ The following completed registration template per RFC8392 is provided:
 * Claim Key: TBD6 (request assignment 11)
 * Claim Value Type(s): bstr
 * Change Controller: IETF
-* Specification Document(s): RFC XXXX
+* Specification Document(s): {{cred-types}} of this specification
 
 ## Media Types
 
-This section requests the registration of new media types in https://www.iana.org/assignments/media-types/media-types.xhtml.
+IANA is requested to add the following entries to the IANA "Media Types" registry (https://www.iana.org/assignments/media-types/media-types.xhtml):
 
 ### application/sd+cwt
-
-IANA is requested to add the following entry to the media types registry in accordance with RFC6838, RFC4289, and RFC6657.
 
 The following completed registration template is provided:
 
@@ -1129,10 +1077,9 @@ The following completed registration template is provided:
 * Required parameters: n/a
 * Optional parameters: n/a
 * Encoding considerations: binary
-* Security considerations: See the Security Considerations section
-  of RFC XXXX, and {{RFC8392}}
+* Security considerations: {{security}} of this specification and {{RFC8392}}
 * Interoperability considerations: n/a
-* Published specification: RFC XXXX
+* Published specification: {{SD-CWT-def}} of this specification
 * Applications that use this media type: TBD
 * Fragment identifier considerations: n/a
 * Additional information:
@@ -1150,8 +1097,6 @@ The following completed registration template is provided:
 
 ### application/kb+cwt
 
-IANA is requested to add the following entry to the media types registry in accordance with RFC6838, RFC4289, and RFC6657.
-
 The following completed registration template is provided:
 
 * Type name: application
@@ -1159,10 +1104,9 @@ The following completed registration template is provided:
 * Required parameters: n/a
 * Optional parameters: n/a
 * Encoding considerations: binary
-* Security considerations: See the Security Considerations section
-  of RFC XXXX, and {{RFC8392}}
+* Security considerations: {{security}} of this specification and {{RFC8392}}
 * Interoperability considerations: n/a
-* Published specification: RFC XXXX
+* Published specification: {{kbt}} of this specification
 * Applications that use this media type: TBD
 * Fragment identifier considerations: n/a
 * Additional information:
@@ -1180,13 +1124,11 @@ The following completed registration template is provided:
 
 ## Content-Formats
 
-[^rfced] Please replace "{{&SELF}}" with the RFC number assigned to this document.
-
-[^rfced] IANA is requested to register the following Content-Format numbers in the "CoAP Content-Formats" registry, within the "Constrained RESTful Environments (CoRE) Parameters" registry group {{!IANA.core-parameters}}:
+IANA is requested to register the following entries in the "CoAP Content-Formats" registry within the "Constrained RESTful Environments (CoRE) Parameters" registry group {{!IANA.core-parameters}}:
 
 | Content-Type | Content Coding | ID | Reference |
-| application/sd+cwt | - | TBD11 | {{&SELF}} |
-| application/kb+cwt | - | TBD12 | {{&SELF}} |
+| application/sd+cwt | - | TBD11 | {{SD-CWT-def}} of this specification |
+| application/kb+cwt | - | TBD12 | {{kbt}} of this specification |
 {: align="left" title="New CoAP Content Formats"}
 
 If possible, TBD11 and TBD12 should be assigned in the 256..9999 range.
@@ -1202,23 +1144,25 @@ If possible, TBD11 and TBD12 should be assigned in the 256..9999 range.
 
 # Comparison to SD-JWT
 
-SD-CWT is modeled after SD-JWT, with adjustments to align with conventions in CBOR and COSE.
+SD-CWT is modeled after SD-JWT, with adjustments to align with conventions in CBOR, COSE, and CWT.
 
 ## Media Types
 
 The COSE equivalent of `application/sd-jwt` is `application/sd+cwt`.
 
-THe COSE equivalent of `application/kb+jwt` is `application/kb+cwt`.
+The COSE equivalent of `application/kb+jwt` is `application/kb+cwt`.
+
+No COSE equivalent of the "+sd-jwt" media type suffix is presently defined.
 
 ## Redaction Claims
 
-The COSE equivalent of `_sd` is a CBOR tag (requested assignment 59) of the claim key 0. The corresponding claim value is an array of the redacted claim keys.
+The COSE equivalent of `_sd` is a CBOR Simple Value (requested assignment 59). The following value is an array of the redacted claim keys.
 
 The COSE equivalent of `...` is a CBOR tag (requested assignment 60) of the digested salted claim.
 
 In SD-CWT, the order of the fields in a disclosure is salt, value, key.
 In SD-JWT the order of fields in a disclosure is salt, key, value.
-This choice insures that the second element in the CBOR array is always the value, which makes parsing faster and more efficient in strongly-typed programming languages.
+This choice ensures that the second element in the CBOR array is always the value, which makes parsing faster and more efficient in strongly-typed programming languages.
 
 
 ## Issuance
@@ -1233,9 +1177,9 @@ Because the entire SD-CWT is included as a claim in the SD-KBT, the disclosures 
 
 ## Validation
 
-The validation process for SD-CWT is similar to SD-JWT, however, JSON Objects are replaced with CBOR Maps which can contain integer keys and CBOR Tags.
+The validation process for SD-CWT is similar to SD-JWT, however, JSON Objects are replaced with CBOR Maps that can contain integer keys and CBOR Tags.
 
-# Keys used in the examples
+# Keys Used in the Examples
 
 ## Subject / Holder
 
@@ -1244,7 +1188,7 @@ Holder COSE key pair in EDN format
 ~~~ cbor-diag
 {
   /kty/  1 : 2, /EC/
-  /alg/  3 : -7, /ES256/
+  /alg/  3 : -9, /ESP256/
   /crv/ -1 : 1, /P-256/
   /x/   -2 : h'8554eb275dcd6fbd1c7ac641aa2c90d9
                2022fd0d3024b5af18c7cc61ad527a2d',
@@ -1351,7 +1295,7 @@ Issuer COSE key pair in Extended Diagnostic Notation (EDN)
 {
   /kty/  1 : 2, /EC/
   /kid/  2 : "https://issuer.example/cwk3.cbor",
-  /alg/  3 : -35, /ES384/
+  /alg/  3 : -51, /ESP384/
   /crv/ -1 : 2, /P-384/
   /x/   -2 : h'c31798b0c7885fa3528fbf877e5b4c3a6dc67a5a5dc6b307
                b728c3725926f2abe5fb4964cd91e3948a5493f6ebb6cbbf',
@@ -1456,19 +1400,68 @@ rTdMTaqTh0U/GAWOzljrCo6EoFWjH7f5IUsnUJUiwVnnZPhxHhFglVQ=
 ~~~
 
 
+# Implementation Status
+
+Note to the RFC Editor: Please remove this section as well as references to {{BCP205}} before AUTH48.
+
+This section records the status of known implementations of the protocol defined by this specification at the time of posting of this Internet-Draft, and is based on a proposal described in {{BCP205}}.
+The description of implementations in this section is intended to assist the IETF in its decision processes in progressing drafts to RFCs.
+Please note that the listing of any individual implementation here does not imply endorsement by the IETF.
+Furthermore, no effort has been made to verify the information presented here that was supplied by IETF contributors.
+This is not intended as, and must not be construed to be, a catalog of available implementations or their features.
+Readers are advised to note that other implementations may exist.
+
+According to {{BCP205}}, "This will allow reviewers and working groups to assign due consideration to documents that have the benefit of running code, which may serve as evidence of valuable experimentation and feedback that have made the implemented protocols more mature.
+It is up to the individual working groups to use this information as they see fit".
+
+## Transmute Prototype
+
+Organization: Transmute Industries Inc
+
+Name: [github.com/transmute-industries/sd-cwt](https://github.com/transmute-industries/sd-cwt)
+
+Description: An open-source implementation of this specification.
+
+Maturity: Prototype
+
+Coverage: The current version ('main') implements functionality similar to that described in this specification, and will be revised, with breaking changes to support the generation of example data to support this specification.
+
+License: Apache-2.0
+
+Implementation Experience: No interop testing has been done yet. The code works as a proof of concept, but is not yet production ready.
+
+Contact: Orie Steele (orie@transmute.industries)
+
+## Rust Prototype
+
+Organization: SimpleLogin
+
+Name: [github.com/beltram/esdicawt](https://github.com/beltram/esdicawt)
+
+Description: An open-source Rust implementation of this specification in Rust.
+
+Maturity: Prototype
+
+Coverage: The current version is close to the spec with the exception of `redacted_claim_keys` using a CBOR SimpleValue as label instead of a tagged key. Not all of the verifications have been implemented yet.
+
+License: Apache-2.0
+
+Implementation Experience: No interop testing has been done yet. The code works as a proof of concept, but is not yet production ready.
+
+Contact: Beltram Maldant (beltram.ietf.spice@pm.me)
+
+
 # Document History
 
 Note: RFC Editor, please remove this entire section on publication.
-
-## draft-ietf-spice-sd-cwt-05
-
-- add AEAD and COSE encrypted disclosures
 
 ## draft-ietf-spice-sd-cwt-04
 
 - use CBOR simple value 59 for the redacted_key_claims
 - add description of decoy digests **TODO**
 - provide test vectors **TODO**
+- add AEAD and COSE encrypted disclosures
+- Applied clarifications and corrections suggested by Mike Jones.
 
 ## draft-ietf-spice-sd-cwt-03
 
@@ -1496,7 +1489,7 @@ Note: RFC Editor, please remove this entire section on publication.
 
 - Added Overview section
 - Rewrote the main normative section
-- Made redaacted_claim_keys use an unlikely to collide claim key integer
+- Made redacted_claim_keys use an unlikely to collide claim key integer
 - Make cnonce optional (it now says SHOULD)
 - Made most standard claims optional.
 - Consistently avoid use of bare term "key" - to make crypto keys and map keys clear
@@ -1517,6 +1510,7 @@ Note: RFC Editor, please remove this entire section on publication.
 The authors would like to thank those that have worked on similar items for
 providing selective disclosure mechanisms in JSON, especially:
 Brent Zundel, Roy Williams, Tobias Looker, Kristina Yasuda, Daniel Fett,
-Brian Campbell, Oliver Terbu, and Michael Jones.
+Brian Campbell, Oliver Terbu, and Michael B. Jones.
 
-[^rfced]: RFC Editor:
+The authors would like to thank the following individuals for their contributions to this specification:
+Michael B. Jones.

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -85,7 +85,7 @@ This specification enables Holders of CWT-based credentials to prove the integri
 Although techniques such as one time use and batch issuance can improve the confidentiality and security characteristics of CWT-based credential protocols, CWTs remain traceable.
 Selective Disclosure CBOR Web Tokens (SD-CWTs) are CWTs and can be deployed in protocols that are already using CWTs, even if they contain no optional to disclose claims.
 Credential types are distinguished by their attributes, for example, a license to operate a vehicle and a license to import a product will contain different attributes.
-The specification of credential types is out of scope for this specification and the examples used in this specification are informative.
+The specification of credential types is out of scope for this specification, and the examples used in this specification are informative.
 
 SD-CWT operates on CWT Claims Sets as described in {{RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.


### PR DESCRIPTION
This PR results from me reading the entire specification.  I applied corrections and clarifications, including corrections to use standard COSE and CWT terminology, where applicable.  I also ran it through a spelling and grammar checker.

The only non-obvious change I made was to move the Implementation Status section to an appendix, since it will be deleted by the RFC Editor.

I'll next file a set of issues containing questions for which the answers weren't sufficiently clear to simply include in this PR.
 
@mprorock @OR13 @brentzundel @rohanmahy @henkbirkholz please review.