### PR TITLE
Capitalize defined terms and use Claim Key when that is meant

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -84,7 +84,7 @@ The approach is based on the Selective Disclosure JSON Web Token (SD-JWT), with 
 
 # Introduction
 
-This specification creates a new format based on the CBOR Web Token (CWT) specification {{!RFC8392}}, enabling the holder of a CWT to disclose or redact special claims marked as selectively disclosable by the issuer of a CWT.
+This specification creates a new format based on the CBOR Web Token (CWT) specification {{!RFC8392}}, enabling the Holder of a CWT to disclose or redact special claims marked as selectively disclosable by the Issuer of a CWT.
 The approach is modeled after SD-JWT {{-SD-JWT}}, with changes to align with conventions from CBOR Object Signing and Encryption (COSE) {{!RFC9052}} and CWT.
 This specification enables Holders of CWT-based credentials to prove the integrity and authenticity of selected attributes asserted by an Issuer about a Subject to a Verifier.
 
@@ -95,8 +95,8 @@ The specification of credential types is out of scope for this specification, an
 
 SD-CWT operates on CWT Claims Sets as described in {{!RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.
-SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a holder of a CWT to disclose.
-A verifier that does not understand selective disclosure at all cannot process redacted Claim Keys sent by the Holder.
+SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a Holder of a CWT to disclose.
+A Verifier that does not understand selective disclosure at all cannot process redacted Claim Keys sent by the Holder.
 However, Claim Keys and Claim Values that are not understood remain ignored, as described in {{Section 3 of !RFC8392}}.
 
 ## High-Level Flow
@@ -133,8 +133,8 @@ This diagram captures the essential details necessary to issue and present an SD
 The parameters necessary to support these processes can be obtained using transports or protocols that are out of scope for this specification.
 However, the following guidance is generally recommended, regardless of protocol or transport.
 
-1. The issuer SHOULD confirm the holder controls all confirmation material before issuing credentials using the `cnf` claim.
-2. To protect against replay attacks, the verifier SHOULD provide a nonce, and reject requests that do not include an acceptable nonce (cnonce). This guidance can be ignored in cases where replay attacks are mitigated at another layer.
+1. The Issuer SHOULD confirm the Holder controls all confirmation material before issuing credentials using the `cnf` claim.
+2. To protect against replay attacks, the Verifier SHOULD provide a nonce, and reject requests that do not include an acceptable nonce (cnonce). This guidance can be ignored in cases where replay attacks are mitigated at another layer.
 
 
 # Terminology
@@ -189,7 +189,7 @@ Presented Disclosed Claims Set:
 : The CBOR map containing zero or more Redacted Claim Keys or Redacted Claim Elements.
 
 Validated Disclosed Claims Set:
-: The CBOR map containing all mandatory to disclose claims signed by the issuer, all selectively disclosed claims presented by the holder, and omitting all undisclosed instances of Redacted Claim Keys and Redacted Claim Element claims that are present in the original SD-CWT.
+: The CBOR map containing all mandatory to disclose claims signed by the Issuer, all selectively disclosed claims presented by the Holder, and omitting all undisclosed instances of Redacted Claim Keys and Redacted Claim Element claims that are present in the original SD-CWT.
 
 
 
@@ -198,7 +198,7 @@ Validated Disclosed Claims Set:
 ## A CWT without Selective Disclosure
 
 Below is the payload of a standard CWT not using selective disclosure.
-It consists of standard CWT claims, the holder confirmation key, and five specific custom claims. The payload is shown below in CBOR Extended Diagnostic
+It consists of standard CWT claims, the Holder confirmation key, and five specific custom claims. The payload is shown below in CBOR Extended Diagnostic
 Notation (EDN) {{!I-D.ietf-cbor-edn-literals}}. Note that some of the CWT claim map keys shown in the examples have been invented for this example and do not have registered integer keys.
 
 ~~~ cbor-diag
@@ -237,10 +237,10 @@ The custom claims deal with attributes of an inspection of the subject: the pass
 
 ## Holder gets an SD-CWT from the Issuer
 
-Alice would like to selectively disclose some of these (custom) claims to different verifiers.
+Alice would like to selectively disclose some of these (custom) claims to different Verifiers.
 Note that some of the claims may not be selectively disclosable.
 In our next example, the pass/fail status of the inspection, the most recent inspection date, and the country of the inspection will be claims that are always present in the SD-CWT.
-After the Holder requests an SD-CWT from the issuer, the issuer generates the following SD-CWT:
+After the Holder requests an SD-CWT from the Issuer, the Issuer generates the following SD-CWT:
 
 ~~~ cbor-diag
 {::include examples/issuer_cwt.edn}
@@ -249,7 +249,7 @@ After the Holder requests an SD-CWT from the issuer, the issuer generates the fo
 
 
 Some of the claims are *redacted* in the payload. The corresponding *disclosure* is communicated in the unprotected header in the `sd_claims` header parameter.
-For example, the `inspector_license_number` claim is a Salted Disclosed Claim, consisting of a per-disclosure random salt, the claim name, and claim value.
+For example, the `inspector_license_number` claim is a Salted Disclosed Claim, consisting of a per-disclosure random salt, the Claim Key, and Claim Value.
 
 ~~~ cbor-diag
 {::include examples/first-disclosure.edn}
@@ -285,13 +285,13 @@ Redacted claims that are array elements are handled slightly differently, as des
 
 When the Holder wants to send an SD-CWT and disclose none, some, or all of the redacted values, it makes a list of the values to disclose and puts them in `sd_claims` header parameter in the unprotected header.
 
-For example, Alice decides to disclose to a verifier the `inspector_license_number` claim (ABCD-123456), the `region` claim (California), and the earliest date element in the `inspection_dates` array (7-Feb-2019).
+For example, Alice decides to disclose to a Verifier the `inspector_license_number` claim (ABCD-123456), the `region` claim (California), and the earliest date element in the `inspection_dates` array (7-Feb-2019).
 
 ~~~ cbor-diag
 {::include examples/chosen-disclosures.edn}
 ~~~
 
-The Holder MAY fetch a nonce from the Verifier to prevent replay, or obtain a nonce acceptable to the verifier through a process similar to the method described in {{?I-D.ietf-httpbis-unprompted-auth}}.
+The Holder MAY fetch a nonce from the Verifier to prevent replay, or obtain a nonce acceptable to the Verifier through a process similar to the method described in {{?I-D.ietf-httpbis-unprompted-auth}}.
 
 Finally, the Holder generates a Selective Disclosure Key Binding Token (SD-KBT) that ties together the SD-CWT generated by the Issuer (with the disclosures the Holder chose for the Verifier in its unprotected header), the Verifier target audience and optional nonces, and proof of possession of the Holder's private key.
 
@@ -314,10 +314,10 @@ As in CWTs, CBOR maps used in an SD-CWT or SD-KBT also cannot have duplicate key
 >When sorted, map keys in CBOR are arranged in bytewise lexicographic order of the key's deterministic encodings (see Section 4.2.1 of {{RFC8949}}).
 >So, an integer key of 3 is represented in hex as `03`, an integer key of -2 is represented in hex as `21`, and a tag of 60 wrapping a 3 is represented in hex as `D8 3C 03`
 
-Note that holders presenting to a verifier that does not support this specification would need to present a CWT without tagged map keys or simple value map keys.
+Note that Holders presenting to a Verifier that does not support this specification would need to present a CWT without tagged map keys or simple value map keys.
 
 Tagged keys are not registered in the CBOR Web Token Claims IANA registry.
-Instead, the tag provides additional information about the tagged claim key and the corresponding (untagged) value.
+Instead, the tag provides additional information about the tagged Claim Key and the corresponding (untagged) value.
 Multiple levels of tags in a key are not permitted.
 
 Variability in serialization requirements impacts privacy.
@@ -337,7 +337,7 @@ such as a content type value using the `+sd-cwt` structured suffix.
 An SD-CWT is an extension of a CWT that can contain blinded claims (each expressed as a Blinded Claim Hash) in the CWT payload, at the root level or in any arrays or maps inside that payload.
 It is not required to contain any blinded claims.
 
-Optionally the salted claim values (and often claim names) for the corresponding Blinded Claim Hash are disclosed in the `sd_claims` header parameter in the unprotected header of the CWT (the disclosures).
+Optionally the salted Claim Values (and often Claim Keys) for the corresponding Blinded Claim Hash are disclosed in the `sd_claims` header parameter in the unprotected header of the CWT (the disclosures).
 If there are no disclosures (and when no Blinded Claims Hash is present in the payload) the `sd_claims` header parameter in the unprotected header is an empty array.
 
 Any party with a Salted Disclosed Claim can generate its hash, find that hash in the CWT payload, and unblind the content.
@@ -352,12 +352,12 @@ For Salted Disclosed Claims of items in an array, the name is omitted.
 salted = salted-claim / salted-element / decoy
 salted-claim = [
   bstr .size 16,     ; 128-bit salt
-  any,               ; claim value
-  (int / text)       ; claim name
+  any,               ; Claim Value
+  (int / text)       ; Claim Key
 ]
 salted-element = [
   bstr .size 16,     ; 128-bit salt
-  any                ; claim value
+  any                ; Claim Value
 ]
 decoy = [
   bstr .size 16      ; 128-bit salt
@@ -380,7 +380,7 @@ redacted_claim_element = #6.60( bstr )
 Blinded claims can be nested. For example, both individual keys in the `inspection_location` claim, and the entire `inspection_location` element can be separately blinded.
 An example nested claim is shown in {{nesting}}.
 
-Finally, an issuer MAY create decoy digests, which look like blinded claim hashes but have only a salt.
+Finally, an Issuer MAY create decoy digests, which look like blinded claim hashes but have only a salt.
 Decoy digests are discussed in {{decoys}}.
 
 
@@ -398,7 +398,7 @@ If there are no disclosures, the `sd_claims` header parameter value is an empty 
 The payload also MUST include a key confirmation element (`cnf`) {{!RFC8747}} for the Holder's public key.
 
 In an SD-CWT, either the subject `sub` / 2 claim MUST be present, or the redacted form of the subject MUST be present.
-The issuer `iss` / 1 claim SHOULD be present unless the protected header contains a certificate or certificate-like entity that fully identifies the issuer.
+The `iss` / 1 claim SHOULD be present unless the protected header contains a certificate or certificate-like entity that fully identifies the Issuer.
 All other standard CWT claims (`aud` / 3, `exp` / 4, `nbf` / 5, `iat` / 6, and `cti` / 7) are OPTIONAL.
 The `cnonce` / 39 claim is OPTIONAL.
 The `cnf` / 8 claim, the `cnonce` / 39 claim, and the standard claims other than the subject MUST NOT be redacted.
@@ -491,7 +491,7 @@ Regardless if it discloses any claims, the Holder sends the Verifier a unique Ho
 An SD-KBT is itself a type of CWT, signed using the private key corresponding to the key in the `cnf` claim in the presented SD-CWT.
 The SD-KBT contains the SD-CWT, including the Holder's choice of presented disclosures, in the `kcwt` protected header field in the SD-KBT.
 
-The Holder is conceptually both the subject and the issuer of the Key Binding Token.
+The Holder is conceptually both the subject and the Issuer of the Key Binding Token.
 Therefore, the `sub` and `iss` of an SD-KBT are implied from the `cnf` claim in the included SD-CWT, and MUST NOT be present in the SD-KBT.
 (Profiles of this specification MAY define additional semantics.)
 
@@ -551,7 +551,7 @@ The exact order of the following steps MAY be changed, as long as all checks are
 
 {::options nested_ol_types="1, a, i" /}
 
- 1. First the Verifier must open the protected headers of the SD-KBT and find the issuer SD-CWT present in the `kcwt` field.
+ 1. First the Verifier must open the protected headers of the SD-KBT and find the Issuer SD-CWT present in the `kcwt` field.
 
  2. Next, the Verifier must validate the SD-CWT as described in {{Section 7.2 of !RFC8392}}.
 
@@ -568,10 +568,10 @@ The exact order of the following steps MAY be changed, as long as all checks are
 By performing these steps, the recipient can cryptographically verify the integrity of the protected claims and verify they have not been tampered with.
     3. If there remain unused claims in the Digest To Disclosed Claim Map at the end of this procedure the SD-CWT MUST be considered invalid.
 
-    > Note: A verifier MUST be prepared to process disclosures in any order. When disclosures are nested, a disclosed value could appear before the disclosure of its parent.
+    > Note: A Verifier MUST be prepared to process disclosures in any order. When disclosures are nested, a disclosed value could appear before the disclosure of its parent.
 
 {:start="6"}
- 6. A verifier MUST reject the SD-CWT if the audience claim in either the SD-CWT or the SD-KBT contains a value that does not correspond to the intended recipient.
+ 6. A Verifier MUST reject the SD-CWT if the audience claim in either the SD-CWT or the SD-KBT contains a value that does not correspond to the intended recipient.
 
  7. Otherwise, the SD-CWT is considered valid, and the Validated Disclosed Claims Set is now a CWT Claims Set with no claims marked for redaction.
 
@@ -583,7 +583,7 @@ By performing these steps, the recipient can cryptographically verify the integr
 
 # Encrypted Disclosures
 
-Some uses of SD-CWT involve verifiers that have internal structure.
+Some uses of SD-CWT involve Verifiers that have internal structure.
 In these cases, encrypted disclosures allow more fine-grained disclosure inside a single presentation.
 
 > In the Remote Attestation Procedures (RATS) architecture {{?RFC9334}}, an SD-CWT is a RATS conceptual message that represents evidence.
@@ -593,11 +593,11 @@ In these cases, encrypted disclosures allow more fine-grained disclosure inside 
 
 > In the Messaging Layer Security (MLS) protocol {{?RFC9420}}, an SD-CWT credential {{?I-D.mahy-mls-sd-cwt-credential}} could present one subset of its disclosures to the MLS Distribution Service, and a different subset of those disclosures to the other members of the MLS group.
 
-The entire SD-CWT is included in the protected header of the SD-KBT, which secured the entire issuer signed SD-CWT including its unprotected headers that include its disclosures.
+The entire SD-CWT is included in the protected header of the SD-KBT, which secured the entire Issuer-signed SD-CWT including its unprotected headers that include its disclosures.
 
-When encrypted disclosures are present, they MUST be in the unprotected headers of the issuer signed SD-CWT, before the SD-KBT can be generated by the holder.
+When encrypted disclosures are present, they MUST be in the unprotected headers of the Issuer-signed SD-CWT, before the SD-KBT can be generated by the Holder.
 
-The verifier of the key binding token might not be able to decrypt encrypted disclosures and MAY decide to forward them to an inner verifier that can decrypt them.
+The Verifier of the key binding token might not be able to decrypt encrypted disclosures and MAY decide to forward them to an inner Verifier that can decrypt them.
 
 ## AEAD Encrypted Disclosures {#aead}
 
@@ -634,7 +634,7 @@ The resulting array is placed in the `sd_encrypted_claims` header parameter in t
 
 The blinded claim hash is still over the unencrypted disclosure.
 The receiver of an encrypted disclosure locates the appropriate key by looking up the mac.
-If the verifier is able to decrypt and verify an encrypted disclosure, the decrypted disclosure is then processed as if it were in the `sd_claims` header parameter in the unprotected headers of the SD-CWT.
+If the Verifier is able to decrypt and verify an encrypted disclosure, the decrypted disclosure is then processed as if it were in the `sd_claims` header parameter in the unprotected headers of the SD-CWT.
 
 Details of key management are left to the specific protocols that make use of encrypted disclosures.
 
@@ -853,7 +853,7 @@ Verifiers start unblinding claims for which they have blinded claim hashes. They
 ]
 ~~~
 
-After applying the disclosures of the nested structure above, the disclosed Claims Set visible to the verifier would look like the following:
+After applying the disclosures of the nested structure above, the disclosed Claims Set visible to the Verifier would look like the following:
 
 ~~~ cbor-diag
 {
@@ -892,18 +892,18 @@ Security considerations from COSE {{!RFC9052}} and CWT {{!RFC8392}} apply to thi
 
 ## Transparency
 
-Verification of an SD-CWT requires that the verifier have access to a verification key (public key) associated with the issuer.
-Compromise of the issuer's signing key would enable an attacker to forge credentials for any subject associated with the issuer.
-Certificate transparency, as described in {{-CT}}, or key transparency, as described in {{-KT}}, can enable the observation of incorrectly issued certificates or fraudulent bindings between verification keys and issuer identifiers.
+Verification of an SD-CWT requires that the Verifier have access to a verification key (public key) associated with the Issuer.
+Compromise of the Issuer's signing key would enable an attacker to forge credentials for any subject associated with the Issuer.
+Certificate transparency, as described in {{-CT}}, or key transparency, as described in {{-KT}}, can enable the observation of incorrectly issued certificates or fraudulent bindings between verification keys and Issuer identifiers.
 Issuers choose which claims to include in an SD-CWT, and whether they are mandatory to disclose, including self-asserted claims such as "iss".
-All mandatory to disclose data elements are visible to the verifier as part of verification. Some of these elements reveal information about the issuer, such as key or certificate thumbprints, supported digital signature algorithms, and operational windows that can be inferred from analysis of timestamps.
+All mandatory to disclose data elements are visible to the Verifier as part of verification. Some of these elements reveal information about the Issuer, such as key or certificate thumbprints, supported digital signature algorithms, and operational windows that can be inferred from analysis of timestamps.
 
 ## Correlation
 
-Presentations of the same SD-CWT to multiple verifiers can be correlated by matching on the signature component of the COSE_Sign1.
+Presentations of the same SD-CWT to multiple Verifiers can be correlated by matching on the signature component of the COSE_Sign1.
 Signature based linkability can be mitigated by leveraging batch issuance of single-use tokens, at a credential management complexity cost.
-Any claim value with sufficiently low "anonymity set" can be used to track the subject.
-For example, a high precision issuance time might match the issuance of only a few credentials for a given issuer, and as such, any presentation of a credential issued at that time can be determined to be associated with the set of credentials issued at that time, for those subjects.
+Any Claim Value with sufficiently low "anonymity set" can be used to track the subject.
+For example, a high precision issuance time might match the issuance of only a few credentials for a given Issuer, and as such, any presentation of a credential issued at that time can be determined to be associated with the set of credentials issued at that time, for those subjects.
 
 ## Credential Types
 
@@ -922,23 +922,23 @@ The construction of such profiles has a significant impact on the privacy proper
 Each use case will have a unique threat model that MUST be considered before the applicability of SD-CWT-based credential types can be determined.
 This section provides a non-exhaustive list of topics to be considered when developing a threat model for applying SD-CWT to a given use case.
 
-1. Has there been a t-closeness, k-anonymity, and l-diversity assessment (see {{t-Closeness}}) assuming compromise of the one or more issuers, verifiers or holders, for all relevant credential types?
+1. Has there been a t-closeness, k-anonymity, and l-diversity assessment (see {{t-Closeness}}) assuming compromise of the one or more Issuers, Verifiers or Holders, for all relevant credential types?
 
 2. Issuer questions:
-   1. How many issuers exist for the credential type?
-   2. Is the size of the set of issuers growing or shrinking over time?
-   3. For a given credential type, will subjects be able to hold instances of the same credential type from multiple issuers, or just a single issuer?
+   1. How many Issuers exist for the credential type?
+   2. Is the size of the set of Issuers growing or shrinking over time?
+   3. For a given credential type, will subjects be able to hold instances of the same credential type from multiple Issuers, or just a single Issuer?
    4. Does the credential type require or offer the ability to disclose a globally unique identifier?
    5. Does the credential type require high precision time or other claims that have sufficient entropy such that they can serve as a unique fingerprint for a specific subject?
    6. Does the credential type contain Personally Identifiable Information (PII), or other sensitive information that might have value in a market?
 
 3. Verifier questions:
-   1. How many verifiers exist for the credential type?
-   2. Is the size of the set of verifiers growing or shrinking over time?
-   3. Are the verifiers a superset, subset, or disjoint set of the issuers or subjects?
-   4. Are there any legally required reporting or disclosure requirements associated with the verifiers?
-   5. Is there reason to believe that a verifier's historic data will be aggregated and analyzed?
-   6. Assuming multiple verifiers are simultaneously compromised, what knowledge regarding subjects can be inferred from analyzing the resulting dataset?
+   1. How many Verifiers exist for the credential type?
+   2. Is the size of the set of Verifiers growing or shrinking over time?
+   3. Are the Verifiers a superset, subset, or disjoint set of the Issuers or subjects?
+   4. Are there any legally required reporting or disclosure requirements associated with the Verifiers?
+   5. Is there reason to believe that a Verifier's historic data will be aggregated and analyzed?
+   6. Assuming multiple Verifiers are simultaneously compromised, what knowledge regarding subjects can be inferred from analyzing the resulting dataset?
 
 4. Subject questions:
    1. How many subjects exist for the credential type?
@@ -947,29 +947,29 @@ This section provides a non-exhaustive list of topics to be considered when deve
 
 ## Random Numbers
 
-Each salt used to protect disclosed claims MUST be generated independently from the salts of other claims. The salts MUST be generated from a source of entropy that is acceptable to the issuer.
+Each salt used to protect disclosed claims MUST be generated independently from the salts of other claims. The salts MUST be generated from a source of entropy that is acceptable to the Issuer.
 Poor choice of salts can lead to brute force attacks that can reveal redacted claims.
 
 ## Binding the KBT and the CWT
 
-The issuer claim in the SD-CWT is self-asserted by the issuer.
+The "iss" claim in the SD-CWT is self-asserted by the Issuer.
 
 Because confirmation is mandatory, the subject claim of an SD-CWT, when present, is always related directly to the confirmation claim.
 There might be many subject claims and many confirmation keys that identify the same entity or that are controlled by the same entity, while the identifiers and keys are distinct values.
 Reusing an identifier or key enables correlation, but MUST be evaluated in terms of the confidential and privacy constraints associated with the credential type.
-Conceptually, the Holder is both the issuer and the subject of the SD-KBT, even if the issuer or subject claims are not present.
+Conceptually, the Holder is both the Issuer and the subject of the SD-KBT, even if the "iss" or "sub" claims are not present.
 If they are present, they are self-asserted by the Holder.
 All three are represented by the confirmation (public) key in the SD-CWT.
 
-As with any self-assigned identifiers, Verifiers need to take care to verify that the SD-KBT issuer and subject claims match the subject in the SD-KBT, and are a valid representation of the Holder and correspond to the Holder's confirmation key.
+As with any self-assigned identifiers, Verifiers need to take care to verify that the SD-KBT "iss" and "sub" claims match the subject in the SD-KBT, and are a valid representation of the Holder and correspond to the Holder's confirmation key.
 Extra care should be taken in case the SD-CWT subject claim is redacted.
-Likewise, Holders and Verifiers MUST verify that the issuer claim of the SD-CWT corresponds to the Issuer and the key described in the protected header of the SD-CWT.
+Likewise, Holders and Verifiers MUST verify that the "iss" claim of the SD-CWT corresponds to the Issuer and the key described in the protected header of the SD-CWT.
 
 ## Covert Channels
 
-Any data element that is supplied by the issuer, and that appears random to the holder might be used to produce a covert channel between the issuer and the verifier.
+Any data element that is supplied by the Issuer, and that appears random to the Holder might be used to produce a covert channel between the Issuer and the Verifier.
 The ordering of claims, and precision of timestamps can also be used to produce a covert channel.
-This is more of a concern for SD-CWT than typical CWTs, because the holder is usually considered to be aware of the issuer claims they are disclosing to a verifier.
+This is more of a concern for SD-CWT than typical CWTs, because the Holder is usually considered to be aware of the Issuer claims they are disclosing to a Verifier.
 
 ## Nested Disclosure Ordering
 
@@ -1051,7 +1051,7 @@ The following completed registration template per RFC8152 is provided:
 IANA is requested to add the following entry to the [IANA "CBOR Simple Values" registry](https://www.iana.org/assignments/cbor-simple-values#simple):
 
 * Value: TBD4 (requested assignment 59)
-* Semantics: This value as a map key indicates that the claim value is an array of redacted claim keys at the same level as the map key.
+* Semantics: This value as a map key indicates that the Claim Value is an array of redacted Claim Keys at the same level as the map key.
 * Specification Document(s): {{blinded-claims}} of this specification
 
 ## CBOR Tags
@@ -1180,7 +1180,7 @@ If possible, TBD11 and TBD12 should be assigned in the 256..9999 range.
 This specification establishes the Verifiable Credential Type Identifiers registry, under the [IANA "CBOR Web Token (CWT) Claims" group registry heading](https://www.iana.org/assignments/cwt/cwt.xhtml).
 It registers identifiers for the type of the SD-CWT Claims Set.
 
-It enables short integers in the range 0-65535 to be used as `vct` claim values, similarly to how CoAP Content-Formats ({{Section 12.3 of ?RFC7252}}) enable short integers to be used as `typ` header parameter {{!RFC9596}} values.
+It enables short integers in the range 0-65535 to be used as `vct` Claim Values, similarly to how CoAP Content-Formats ({{Section 12.3 of ?RFC7252}}) enable short integers to be used as `typ` header parameter {{!RFC9596}} values.
 
 The registration procedures for numbers in specific ranges are as described below:
 
@@ -1232,10 +1232,10 @@ that Expert should defer to the judgment of the other Experts.
 ### Registration Template
 
 Verifiable Credential Type Identifier String:
-: String identifier for use as a JWT `vct` or CWT `vct` claim value.  It is a StringOrURI value.
+: String identifier for use as a JWT `vct` or CWT `vct` Claim Value.  It is a StringOrURI value.
 
 Verifiable Credential Type Identifier Number:
-: Integer in the range 0-64999 for use as a CWT `vct` claim value.  (Integers in the range 65000-65535 are not to be registered.)
+: Integer in the range 0-64999 for use as a CWT `vct` Claim Value.  (Integers in the range 65000-65535 are not to be registered.)
 
 Description:
 : Brief description of the verifiable credential type
@@ -1277,7 +1277,7 @@ The COSE equivalent of the `+sd-jwt` structured suffix is `+sd-cwt`.
 
 ## Redaction Claims
 
-The COSE equivalent of `_sd` is a CBOR Simple Value (requested assignment 59). The following value is an array of the redacted claim keys.
+The COSE equivalent of `_sd` is a CBOR Simple Value (requested assignment 59). The following value is an array of the redacted Claim Keys.
 
 The COSE equivalent of `...` is a CBOR tag (requested assignment 60) of the digested salted claim.
 
@@ -1587,6 +1587,7 @@ Note: RFC Editor, please remove this entire section on publication.
 - Use `application/sd-cwt` media type and define `+sd-cwt` structured suffix.
 - Made SHA-256 be the default `sd_alg` value.
 - Created Verifiable Credential Type Identifiers registry.
+- Corrected places where Claim Name was used when what was meant was Claim Key.
 
 ## draft-ietf-spice-sd-cwt-03
 
@@ -1619,7 +1620,7 @@ Note: RFC Editor, please remove this entire section on publication.
 - Made most standard claims optional.
 - Consistently avoid use of bare term "key" - to make crypto keys and map keys clear
 - Make clear issued SD-CWT can contain zero or more redactions; presented SD-CWT can disclose zero, some, or all redacted claims.
-- Clarified use of sd_hash for issuer to holder case._
+- Clarified use of sd_hash for issuer to holder case.
 - Lots of editorial cleanup
 - Added Rohan as an author and Brian Campbell to Acknowledgements
 - Updated implementation status section to be BCP205-compatible


### PR DESCRIPTION
Fixes #86 

Also replaces uses of Claim Name with Claim Key when that's what is meant.