### PR TITLE
A verifier cannot process optional claims

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -97,7 +97,7 @@ The specification of credential types is out of scope for this specification, an
 SD-CWT operates on CWT Claims Sets as described in {{!RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.
 SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a Holder of a CWT to disclose.
-A Verifier that does not understand selective disclosure at all can only process mandatory Claim Keys sent by the Holder;
+A Verifier that does not understand selective disclosure at all can only act on unblinded claims sent by the Holder; it will ignore Blinded Claims representing array items, and will fail to process any SD-CWT containing Blinded Claims that represent map keys.
 optional Claim Keys, whether they are disclosed or not, can only be processed by a Verifier that understands this specification.
 However, Claim Keys and Claim Values that are not understood remain ignored, as described in {{Section 3 of !RFC8392}}.
 

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -97,7 +97,8 @@ The specification of credential types is out of scope for this specification, an
 SD-CWT operates on CWT Claims Sets as described in {{!RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.
 SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a Holder of a CWT to disclose.
-A Verifier that does not understand selective disclosure at all cannot process redacted Claim Keys sent by the Holder.
+A Verifier that does not understand selective disclosure at all can only process mandatory Claim Keys sent by the Holder;
+optional Claim Keys, whether they are disclosed or not, can only processed by a Verifier that understands this specification.
 However, Claim Keys and Claim Values that are not understood remain ignored, as described in {{Section 3 of !RFC8392}}.
 
 ## High-Level Flow
@@ -110,7 +111,7 @@ Issuer                           Holder                         Verifier
   |                                +---+                             |
   |                                |   | Key Gen                     |
   |        Request SD-CWT          |<--+                             |
-  |<-------------------------------|                                 |
+  |<-------------------------------+                                 |
   |                                |                                 |
   +------------------------------->|             Request Nonce       |
   |        Receive SD-CWT          +-------------------------------->|

--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -98,7 +98,7 @@ SD-CWT operates on CWT Claims Sets as described in {{!RFC8392}}.
 CWT Claims Sets contain Claim Keys and Claim Values.
 SD-CWT enables Issuers to mark certain Claim Keys or Claim Values mandatory or optional for a Holder of a CWT to disclose.
 A Verifier that does not understand selective disclosure at all can only process mandatory Claim Keys sent by the Holder;
-optional Claim Keys, whether they are disclosed or not, can only processed by a Verifier that understands this specification.
+optional Claim Keys, whether they are disclosed or not, can only be processed by a Verifier that understands this specification.
 However, Claim Keys and Claim Values that are not understood remain ignored, as described in {{Section 3 of !RFC8392}}.
 
 ## High-Level Flow


### PR DESCRIPTION
The text here originally implied that a verifier might be able to process optional claims if they are disclosed.  My understanding is that this is not possible because the verifier needs to process the hash and understand how to link that to the separate disclosure of those claims.  That makes all optional claims inaccessible to a non-SD CWT processor.  (This is hardly a major problem in the spectrum of possibilities for backwards-compatibility.)