### PR TITLE
Address early IANA feedback about the escalation process

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -1355,8 +1355,8 @@ Within the review period, the Designated Experts will either approve or deny
 the registration request, communicating this decision to the review list and IANA.
 Denials should include an explanation and, if applicable,
 suggestions as to how to make the request successful.
-The IANA escalation process is followed when the Designated Experts
-are not responsive within 14 days.
+The IANA escalation process can be initiated by the party requesting registration
+when the Designated Experts are not responsive within 14 days.
 
 Criteria that should be applied by the Designated Experts includes
 determining whether the proposed registration duplicates existing functionality,
@@ -1863,6 +1863,10 @@ Likewise, if this algorithm results in any duplicate CBOR map keys, the entire S
 # Document History
 
 Note: RFC Editor, please remove this entire section on publication.
+
+## draft-ietf-spice-sd-cwt-06
+
+- Addressed early IANA feedback about the escalation process.
 
 ## draft-ietf-spice-sd-cwt-05
 


### PR DESCRIPTION
Feedback received in "[IANA #1423659] Early review: draft-ietf-spice-glue-id-01 (IETF 123)" said:

> 4) A note about the mailing list: this states that IANA should escalate if the experts miss the two-week deadline, but because IANA doesn’t monitor expert review mailing lists, the requester would have to be aware that they need to contact us in order to get the request escalated. It might be useful to either point this out or tell requesters to write to IANA, and have IANA send it to the list with the experts in copy, so we can track/ping. (This issue is also being pointed out to the draft-ietf-spice-sd-cwt authors.)

I also applied this fix in https://github.com/ietf-wg-spice/draft-ietf-spice-glue-id/pull/39/.
