### PR TITLE
Redacting claim keys might not be "often"

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -425,7 +425,7 @@ Unlike CWT, SD-CWT requires key binding.
 An SD-CWT can contain blinded claims (each expressed as a Blinded Claim Hash), at the root level or in any arrays or maps inside that claim set.
 It is not required to contain any blinded claims.
 
-Optionally the salted Claim Values (and often Claim Keys) for the corresponding Blinded Claim Hash are disclosed in the `sd_claims` header parameter in the unprotected header of the CWT (the disclosures).
+Optionally the salted Claim Values (and Claim Keys) for the corresponding Blinded Claim Hash are disclosed in the `sd_claims` header parameter in the unprotected header of the CWT (the disclosures).
 If there are no disclosures (and when no Blinded Claims Hash is present in the payload) the `sd_claims` header parameter is not present in the unprotected header.
 
 Any party with a Salted Disclosed Claim can generate its hash, find that hash in the CWT payload, and unblind the content.


### PR DESCRIPTION
If you think about the potential for information leakage, for the same reason we have decoy values, hiding claim keys is probably not going to be that effective in a lot of cases.  Where the underlying structure is predictable, which I expect to be the common case, redacting the claim key buys nothing.  So I think claiming that keys will often be included is making a prediction that doesn't seem to have evidence to support it.

Better to avoid the prediction.