### PR TITLE
A trailing dot on the section number doesn't work

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -1340,7 +1340,7 @@ Verifiers SHOULD leverage transparency mechanisms where available to validate th
 
 ## Disclosure Coercion and Over-identification {#disclosure-coercion}
 
-The Security Considerations from {{Section 10.2. of -SD-JWT}} apply, with additional attention to disclosure coercion risks.
+The Security Considerations from {{Section 10.2 of -SD-JWT}} apply, with additional attention to disclosure coercion risks.
 Holders face risks of being coerced into disclosing more claims than necessary. This threat warrants special attention because:
 
 1. Verifier Trust: Holders MUST be able to verify that a Verifier will handle disclosed claims appropriately and only for stated purposes.


### PR DESCRIPTION
The resulting link doesn't work.

Attention @cabo, kramdown-rfc passed this through.  Should it have?