### PR TITLE
Remove transparency mechanisms text from Issuer Key Compromise section

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -1260,15 +1260,6 @@ Compromise of the Issuer's signing key would enable an attacker to forge credent
 Beyond key compromise, attacks targeting the provisioning and binding between issuer names and their cryptographic key material pose significant risks.
 An attacker who can manipulate these bindings could substitute their own keys for legitimate issuer keys, enabling credential forgery while appearing to be a trusted issuer.
 
-Certificate transparency, as described in {{-CT}}, or key transparency, as described in {{-KT}}, can help detect and prevent such attacks by:
-
-- Enabling public observation of all issued certificates or key bindings
-- Detecting unauthorized or fraudulent bindings between verification keys and Issuer identifiers
-- Providing cryptographic proof of inclusion for legitimate keys
-- Creating an append-only audit trail that makes key substitution attacks discoverable
-
-Verifiers SHOULD leverage transparency mechanisms where available to validate that the issuer's keys have not been compromised or fraudulently substituted.
-
 ## Disclosure Coercion and Over-identification {#disclosure-coercion}
 
 The Security Considerations from {{Section 10.2 of -SD-JWT}} apply, with additional attention to disclosure coercion risks.


### PR DESCRIPTION
Closes #227

## Summary
- Removes the Certificate transparency / key transparency bullet-point list from the Issuer Key Compromise security consideration
- Removes the associated `Verifiers SHOULD leverage transparency mechanisms...` paragraph

## Test plan
- [ ] Verify the Issuer Key Compromise section reads cleanly without the removed paragraphs
- [ ] Confirm no dangling references to `{{-CT}}` or `{{-KT}}` remain in the document

🤖 Generated with [Claude Code](https://claude.com/claude-code)