### PR TITLE
Clarify Issuer key authentication in §16.1 (#226)

### DIFF
--- a/draft-ietf-spice-sd-cwt.md
+++ b/draft-ietf-spice-sd-cwt.md
@@ -1327,8 +1327,8 @@ Security considerations from COSE {{!RFC9052}} and CWT {{!RFC8392}} apply to thi
 
 Verification of an SD-CWT requires that the Verifier have access to a verification key (public key) associated with the Issuer.
 Compromise of the Issuer's signing key would enable an attacker to forge credentials for any subject, potentially undermining the entire trust model of the credential system.
-Beyond key compromise, attacks targeting the provisioning and binding between issuer names and their cryptographic key material pose significant risks.
-An attacker who can manipulate these bindings could substitute their own keys for legitimate issuer keys, enabling credential forgery while appearing to be a trusted issuer.
+Beyond key compromise, an attacker might seek to attack the process by which a Verifier obtains the public keys of Issuers.
+An attacker who can manipulate the process by which a Verifier obtains information about Issuer public keys could substitute their own keys, enabling credential forgery while appearing to be a trusted Issuer.
 
 ## Disclosure Coercion and Over-identification {#disclosure-coercion}
 


### PR DESCRIPTION
## Summary
- Reword §16.1 to describe attacks on the process by which a Verifier obtains Issuer public keys, rather than presuming a name-based binding between Issuers and key material. This addresses Martin Thomson's concern that the Issuer identity may be something other than a name (e.g. a public key directly).
- Fix capitalization of "Issuer" for consistency with the rest of the document.

Wording follows Martin's suggestion in the issue thread.

Closes #226

## Test plan
- [ ] Build the draft locally (`make`) and confirm §16.1 reads as intended
- [ ] Confirm CI build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)